### PR TITLE
feat: impl leveled compaction

### DIFF
--- a/src/compactor/mod.rs
+++ b/src/compactor/mod.rs
@@ -388,6 +388,7 @@ mod tests {
 
     use arrow::array::{GenericBinaryBuilder, RecordBatch};
     use executor::{futures::util::io::Cursor, ExecutorBuilder};
+    use futures::channel::mpsc::channel;
     use parquet::arrow::ArrowWriter;
     use snowflake::ProcessUniqueId;
     use tempfile::TempDir;
@@ -590,9 +591,12 @@ mod tests {
             )
             .await;
 
+            let (sender, _) = channel(1);
+
             let mut version = Version {
                 num: 0,
                 level_slice: Version::level_slice_new(),
+                clean_sender: sender,
             };
             version.level_slice[0].push(Scope {
                 min: Arc::new("key_1".to_string()),
@@ -630,6 +634,7 @@ mod tests {
                 &min,
                 &max,
                 &mut version_edits,
+                &mut vec![],
             )
             .await
             .unwrap();

--- a/src/compactor/mod.rs
+++ b/src/compactor/mod.rs
@@ -229,7 +229,7 @@ where
                     value_builder.append_null();
                 }
 
-                if written_size >= option.sst_file_size {
+                if written_size >= option.max_sst_file_size {
                     Self::build_table(
                         option,
                         version_edits,

--- a/src/compactor/mod.rs
+++ b/src/compactor/mod.rs
@@ -1,4 +1,6 @@
-use std::{collections::VecDeque, fmt::Debug, fs::File, marker::PhantomData, pin::pin, sync::Arc};
+use std::{
+    cmp, collections::VecDeque, fmt::Debug, fs::File, marker::PhantomData, pin::pin, sync::Arc,
+};
 
 use arrow::{
     array::{GenericBinaryBuilder, GenericByteBuilder, RecordBatch},
@@ -179,11 +181,15 @@ where
                     max = max_key;
 
                     let min_index =
-                        Version::<K>::scope_search(min_key, &version.level_slice[level]);
+                        Version::<K>::scope_search(min_key, &version.level_slice[level + 1]);
                     let max_index =
-                        Version::<K>::scope_search(max_key, &version.level_slice[level]);
+                        Version::<K>::scope_search(max_key, &version.level_slice[level + 1]);
 
-                    for scope in version.level_slice[level + 1][min_index..max_index].iter() {
+                    let next_level_len = version.level_slice[level + 1].len();
+                    for scope in version.level_slice[level + 1]
+                        [min_index..cmp::min(max_index + 1, next_level_len - 1)]
+                        .iter()
+                    {
                         if scope.is_between(min) || scope.is_between(max) {
                             meet_scopes_ll.push(scope);
                         }
@@ -365,4 +371,290 @@ where
     Stream(#[source] StreamError<K, V>),
     #[error("the level being compacted does not have a table")]
     EmptyLevel,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::{BTreeMap, VecDeque},
+        fs::File,
+        sync::Arc,
+    };
+
+    use arrow::array::{GenericBinaryBuilder, RecordBatch};
+    use executor::{futures::util::io::Cursor, ExecutorBuilder};
+    use parquet::arrow::ArrowWriter;
+    use snowflake::ProcessUniqueId;
+    use tempfile::TempDir;
+
+    use crate::{
+        compactor::Compactor,
+        index_batch::IndexBatch,
+        mem_table::InternalKey,
+        oracle::LocalOracle,
+        scope::Scope,
+        serdes::Encode,
+        version::{edit::VersionEdit, Version},
+        DbOption, Offset, ELSM_SCHEMA,
+    };
+
+    async fn build_index_batch<K, V>(items: &[(Arc<K>, Option<V>)]) -> IndexBatch<K, u64>
+    where
+        K: Encode + Ord,
+        V: Encode,
+    {
+        fn clear(buf: &mut Cursor<Vec<u8>>) {
+            buf.get_mut().clear();
+            buf.set_position(0);
+        }
+
+        let mut buf = Cursor::new(vec![0; 128]);
+        let mut index = BTreeMap::new();
+        let mut key_builder = GenericBinaryBuilder::<Offset>::new();
+        let mut value_builder = GenericBinaryBuilder::<Offset>::new();
+
+        for (offset, (key, value)) in items.into_iter().enumerate() {
+            clear(&mut buf);
+            key.encode(&mut buf).await.unwrap();
+            key_builder.append_value(buf.get_ref());
+
+            if let Some(value) = value {
+                clear(&mut buf);
+                value.encode(&mut buf).await.unwrap();
+                value_builder.append_value(buf.get_ref());
+            } else {
+                value_builder.append_null();
+            }
+            index.insert(
+                InternalKey {
+                    key: key.clone(),
+                    ts: 0,
+                },
+                offset as u32,
+            );
+        }
+        let keys = key_builder.finish();
+        let values = value_builder.finish();
+
+        let batch =
+            RecordBatch::try_new(ELSM_SCHEMA.clone(), vec![Arc::new(keys), Arc::new(values)])
+                .unwrap();
+
+        IndexBatch { batch, index }
+    }
+
+    async fn build_parquet_table<K: Encode, V: Encode>(
+        option: &DbOption,
+        gen: ProcessUniqueId,
+        items: &[(Arc<K>, Option<V>)],
+    ) {
+        fn clear(buf: &mut Cursor<Vec<u8>>) {
+            buf.get_mut().clear();
+            buf.set_position(0);
+        }
+
+        let mut buf = Cursor::new(vec![0; 128]);
+        let mut key_builder = GenericBinaryBuilder::<Offset>::new();
+        let mut value_builder = GenericBinaryBuilder::<Offset>::new();
+
+        for (key, value) in items.iter() {
+            clear(&mut buf);
+            key.encode(&mut buf).await.unwrap();
+            key_builder.append_value(buf.get_ref());
+
+            if let Some(value) = value {
+                clear(&mut buf);
+                value.encode(&mut buf).await.unwrap();
+                value_builder.append_value(buf.get_ref());
+            } else {
+                value_builder.append_null();
+            }
+        }
+        let keys = key_builder.finish();
+        let values = value_builder.finish();
+
+        let batch =
+            RecordBatch::try_new(ELSM_SCHEMA.clone(), vec![Arc::new(keys), Arc::new(values)])
+                .unwrap();
+
+        let mut writer = ArrowWriter::try_new(
+            File::create(option.table_path(&gen)).unwrap(),
+            ELSM_SCHEMA.clone(),
+            None,
+        )
+        .unwrap();
+        writer.write(&batch).unwrap();
+        writer.close().unwrap();
+    }
+
+    #[test]
+    fn minor_compaction() {
+        let temp_dir = TempDir::new().unwrap();
+
+        ExecutorBuilder::new().build().unwrap().block_on(async {
+            let option = DbOption::new(temp_dir.path().to_path_buf());
+            let batch_1 = build_index_batch::<String, String>(&vec![
+                (Arc::new("key_3".to_string()), Some("value_3".to_string())),
+                (Arc::new("key_5".to_string()), Some("value_5".to_string())),
+                (Arc::new("key_6".to_string()), Some("value_6".to_string())),
+            ])
+            .await;
+            let batch_2 = build_index_batch::<String, String>(&vec![
+                (Arc::new("key_4".to_string()), Some("value_4".to_string())),
+                (Arc::new("key_2".to_string()), Some("value_2".to_string())),
+                (Arc::new("key_1".to_string()), Some("value_1".to_string())),
+            ])
+            .await;
+
+            let scope = Compactor::<String, LocalOracle<String>, String>::minor_compaction(
+                &option,
+                VecDeque::from(vec![batch_2, batch_1]),
+            )
+            .await
+            .unwrap()
+            .unwrap();
+            assert_eq!(scope.min, Arc::new("key_1".to_string()));
+            assert_eq!(scope.max, Arc::new("key_6".to_string()));
+        })
+    }
+
+    #[test]
+    fn major_compaction() {
+        let temp_dir = TempDir::new().unwrap();
+
+        ExecutorBuilder::new().build().unwrap().block_on(async {
+            let mut option = DbOption::new(temp_dir.path().to_path_buf());
+            option.major_threshold_with_sst_size = 2;
+
+            // level 1
+            let table_gen_1 = ProcessUniqueId::new();
+            let table_gen_2 = ProcessUniqueId::new();
+            build_parquet_table(
+                &option,
+                table_gen_1,
+                &vec![
+                    (Arc::new("key_1".to_string()), Some("value_1".to_string())),
+                    (Arc::new("key_2".to_string()), Some("value_2".to_string())),
+                    (Arc::new("key_3".to_string()), Some("value_3".to_string())),
+                ],
+            )
+            .await;
+            build_parquet_table(
+                &option,
+                table_gen_2,
+                &vec![
+                    (Arc::new("key_4".to_string()), Some("value_4".to_string())),
+                    (Arc::new("key_5".to_string()), Some("value_5".to_string())),
+                    (Arc::new("key_6".to_string()), Some("value_6".to_string())),
+                ],
+            )
+            .await;
+
+            // level 2
+            let table_gen_3 = ProcessUniqueId::new();
+            let table_gen_4 = ProcessUniqueId::new();
+            let table_gen_5 = ProcessUniqueId::new();
+            build_parquet_table(
+                &option,
+                table_gen_3,
+                &vec![
+                    (Arc::new("key_1".to_string()), Some("value_1".to_string())),
+                    (Arc::new("key_2".to_string()), Some("value_2".to_string())),
+                    (Arc::new("key_3".to_string()), Some("value_3".to_string())),
+                ],
+            )
+            .await;
+            build_parquet_table(
+                &option,
+                table_gen_4,
+                &vec![
+                    (Arc::new("key_4".to_string()), Some("value_4".to_string())),
+                    (Arc::new("key_5".to_string()), Some("value_5".to_string())),
+                    (Arc::new("key_6".to_string()), Some("value_6".to_string())),
+                ],
+            )
+            .await;
+            build_parquet_table(
+                &option,
+                table_gen_5,
+                &vec![
+                    (Arc::new("key_7".to_string()), Some("value_7".to_string())),
+                    (Arc::new("key_8".to_string()), Some("value_8".to_string())),
+                    (Arc::new("key_9".to_string()), Some("value_9".to_string())),
+                ],
+            )
+            .await;
+
+            let mut version = Version {
+                num: 0,
+                level_slice: Version::level_slice_new(),
+            };
+            version.level_slice[0].push(Scope {
+                min: Arc::new("key_1".to_string()),
+                max: Arc::new("key_3".to_string()),
+                gen: table_gen_1,
+            });
+            version.level_slice[0].push(Scope {
+                min: Arc::new("key_4".to_string()),
+                max: Arc::new("key_6".to_string()),
+                gen: table_gen_2,
+            });
+            version.level_slice[1].push(Scope {
+                min: Arc::new("key_1".to_string()),
+                max: Arc::new("key_3".to_string()),
+                gen: table_gen_3,
+            });
+            version.level_slice[1].push(Scope {
+                min: Arc::new("key_4".to_string()),
+                max: Arc::new("key_6".to_string()),
+                gen: table_gen_4,
+            });
+            version.level_slice[1].push(Scope {
+                min: Arc::new("key_7".to_string()),
+                max: Arc::new("key_9".to_string()),
+                gen: table_gen_5,
+            });
+
+            let min = Arc::new("key_2".to_string());
+            let max = Arc::new("key_5".to_string());
+            let mut version_edits = Vec::new();
+
+            Compactor::<String, LocalOracle<String>, String>::major_compaction(
+                &version,
+                &option,
+                &min,
+                &max,
+                &mut version_edits,
+            )
+            .await
+            .unwrap();
+
+            if let VersionEdit::Add { level, scope } = &version_edits[0] {
+                assert_eq!(*level, 1);
+                assert_eq!(scope.min, Arc::new("key_1".to_string()));
+                assert_eq!(scope.max, Arc::new("key_6".to_string()));
+            }
+            assert_eq!(
+                version_edits[1..5].to_vec(),
+                vec![
+                    VersionEdit::Remove {
+                        level: 0,
+                        gen: table_gen_1,
+                    },
+                    VersionEdit::Remove {
+                        level: 0,
+                        gen: table_gen_2,
+                    },
+                    VersionEdit::Remove {
+                        level: 1,
+                        gen: table_gen_3,
+                    },
+                    VersionEdit::Remove {
+                        level: 1,
+                        gen: table_gen_4,
+                    },
+                ]
+            )
+        })
+    }
 }

--- a/src/index_batch/mod.rs
+++ b/src/index_batch/mod.rs
@@ -41,7 +41,9 @@ where
             .next()
         {
             if item_key == key {
-                return Ok(Some(decode_value::<V>(&self.batch, *offset).await?));
+                return Ok(Some(
+                    decode_value::<V>(&self.batch, 1, *offset as usize).await?,
+                ));
             }
         }
         Ok(None)
@@ -57,11 +59,15 @@ where
     }
 }
 
-pub(crate) async fn decode_value<V>(batch: &RecordBatch, offset: u32) -> Result<Option<V>, V::Error>
+pub(crate) async fn decode_value<V>(
+    batch: &RecordBatch,
+    column: usize,
+    offset: usize,
+) -> Result<Option<V>, V::Error>
 where
     V: Decode + Sync + Send,
 {
-    let bytes = batch.column(1).as_binary::<Offset>().value(offset as usize);
+    let bytes = batch.column(column).as_binary::<Offset>().value(offset);
 
     if bytes.is_empty() {
         return Ok(None);

--- a/src/index_batch/stream.rs
+++ b/src/index_batch/stream.rs
@@ -55,7 +55,7 @@ where
                     Some(true) | None
                 )
             {
-                let mut future = pin!(decode_value::<V>(this.batch, *offset));
+                let mut future = pin!(decode_value::<V>(this.batch, 1, *offset as usize));
 
                 return match future.as_mut().poll(cx) {
                     Poll::Ready(Ok(option)) => Poll::Ready(

--- a/src/index_batch/stream.rs
+++ b/src/index_batch/stream.rs
@@ -15,7 +15,7 @@ use pin_project::pin_project;
 use crate::{
     index_batch::{decode_value, IndexBatch},
     mem_table::InternalKey,
-    serdes::Decode,
+    serdes::{Decode, Encode},
     stream::StreamError,
 };
 
@@ -39,7 +39,7 @@ where
 
 impl<'a, K, T, V, G, F> Stream for IndexBatchStream<'a, K, T, V, G, F>
 where
-    K: Ord + Debug + Decode,
+    K: Ord + Debug + Encode + Decode,
     T: Ord + Copy + Default,
     V: Decode + Send + Sync,
     G: Send + 'static,
@@ -75,7 +75,7 @@ where
 
 impl<K, T> IndexBatch<K, T>
 where
-    K: Ord + Debug + Decode,
+    K: Ord + Debug + Encode + Decode,
     T: Ord + Copy + Default,
 {
     pub(crate) async fn range<V, G, F>(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -511,7 +511,7 @@ where
 
 pub(crate) trait GetWrite<K, V>: Oracle<K>
 where
-    K: Ord + Decode,
+    K: Ord + Encode + Decode,
     V: Decode,
 {
     fn get<G, F>(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,7 @@ pub struct DbOption {
     pub immutable_chunk_num: usize,
     pub major_threshold_with_sst_size: usize,
     pub level_sst_magnification: usize,
-    pub sst_file_size: usize,
+    pub max_sst_file_size: usize,
 }
 
 #[derive(Debug)]
@@ -617,7 +617,7 @@ impl DbOption {
             immutable_chunk_num: 5,
             major_threshold_with_sst_size: 10,
             level_sst_magnification: 10,
-            sst_file_size: 64 * 1024 * 1024,
+            max_sst_file_size: 64 * 1024 * 1024,
         }
     }
 
@@ -844,7 +844,7 @@ mod tests {
                         immutable_chunk_num: 1,
                         major_threshold_with_sst_size: 5,
                         level_sst_magnification: 10,
-                        sst_file_size: 2 * 1024 * 1024,
+                        max_sst_file_size: 2 * 1024 * 1024,
                     },
                 )
                 .await
@@ -1159,7 +1159,7 @@ mod tests {
                         immutable_chunk_num: 1,
                         major_threshold_with_sst_size: 5,
                         level_sst_magnification: 10,
-                        sst_file_size: 2 * 1024 * 1024,
+                        max_sst_file_size: 2 * 1024 * 1024,
                     },
                 )
                 .await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,7 +120,7 @@ where
 impl<K, V, O, WP> Db<K, V, O, WP>
 where
     K: Encode + Decode + Debug + Ord + Hash + Send + Sync + 'static,
-    V: Encode + Decode + Send + Sync + 'static,
+    V: Encode + Decode + Debug + Send + Sync + 'static,
     O: Oracle<K> + 'static,
     O::Timestamp: Encode + Decode + Copy + Send + Sync + 'static,
     WP: WalProvider,

--- a/src/mem_table/stream.rs
+++ b/src/mem_table/stream.rs
@@ -11,6 +11,7 @@ use pin_project::pin_project;
 use crate::{
     mem_table::{InternalKey, MemTable},
     serdes::Decode,
+    stream::StreamError,
 };
 
 #[pin_project]
@@ -29,13 +30,13 @@ where
 
 impl<'a, K, V, T, G, F> Stream for MemTableStream<'a, K, T, V, G, F>
 where
-    K: Ord,
+    K: Ord + Decode,
     T: Ord + Copy,
     V: Decode,
     G: Send + Sync + 'static,
     F: Fn(&V) -> G + Sync + 'static,
 {
-    type Item = Result<(Arc<K>, Option<G>), V::Error>;
+    type Item = Result<(Arc<K>, Option<G>), StreamError<K, V>>;
 
     fn poll_next(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.project();
@@ -59,7 +60,7 @@ where
 
 impl<K, V, T> MemTable<K, V, T>
 where
-    K: Ord,
+    K: Ord + Decode,
     T: Ord + Copy + Default,
     V: Decode,
 {
@@ -93,7 +94,7 @@ where
         upper: Option<&Arc<K>>,
         ts: &T,
         f: F,
-    ) -> Result<MemTableStream<K, T, V, G, F>, V::Error>
+    ) -> Result<MemTableStream<K, T, V, G, F>, StreamError<K, V>>
     where
         G: Send + Sync + 'static,
         F: Fn(&V) -> G + Sync + 'static,

--- a/src/mem_table/stream.rs
+++ b/src/mem_table/stream.rs
@@ -10,7 +10,7 @@ use pin_project::pin_project;
 
 use crate::{
     mem_table::{InternalKey, MemTable},
-    serdes::Decode,
+    serdes::{Decode, Encode},
     stream::StreamError,
 };
 
@@ -30,7 +30,7 @@ where
 
 impl<'a, K, V, T, G, F> Stream for MemTableStream<'a, K, T, V, G, F>
 where
-    K: Ord + Decode,
+    K: Ord + Encode + Decode,
     T: Ord + Copy,
     V: Decode,
     G: Send + Sync + 'static,
@@ -60,7 +60,7 @@ where
 
 impl<K, V, T> MemTable<K, V, T>
 where
-    K: Ord + Decode,
+    K: Ord + Encode + Decode,
     T: Ord + Copy + Default,
     V: Decode,
 {

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -8,7 +8,7 @@ use snowflake::ProcessUniqueId;
 
 use crate::serdes::{Decode, Encode};
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct Scope<K>
 where
     K: Encode + Decode + Ord,
@@ -16,6 +16,19 @@ where
     pub(crate) min: Arc<K>,
     pub(crate) max: Arc<K>,
     pub(crate) gen: ProcessUniqueId,
+}
+
+impl<K> Clone for Scope<K>
+where
+    K: Encode + Decode + Ord,
+{
+    fn clone(&self) -> Self {
+        Scope {
+            min: self.min.clone(),
+            max: self.max.clone(),
+            gen: self.gen,
+        }
+    }
 }
 
 impl<K> Scope<K>

--- a/src/stream/batch_stream.rs
+++ b/src/stream/batch_stream.rs
@@ -9,12 +9,16 @@ use arrow::record_batch::RecordBatch;
 use executor::futures::{FutureExt, Stream};
 use pin_project::pin_project;
 
-use crate::{index_batch::decode_value, serdes::Decode, stream::StreamError};
+use crate::{
+    index_batch::decode_value,
+    serdes::{Decode, Encode},
+    stream::StreamError,
+};
 
 #[pin_project]
 pub(crate) struct BatchStream<K, V>
 where
-    K: Decode + Send + Sync + 'static,
+    K: Encode + Decode + Send + Sync + 'static,
     V: Decode + Send + Sync + 'static,
 {
     pos: usize,
@@ -24,7 +28,7 @@ where
 
 impl<K, V> BatchStream<K, V>
 where
-    K: Decode + Send + Sync + 'static,
+    K: Encode + Decode + Send + Sync + 'static,
     V: Decode + Send + Sync + 'static,
 {
     pub(crate) fn new(batch: RecordBatch) -> Self {
@@ -52,7 +56,7 @@ where
 
 impl<K, V> Stream for BatchStream<K, V>
 where
-    K: Decode + Send + Sync + 'static,
+    K: Encode + Decode + Send + Sync + 'static,
     V: Decode + Send + Sync + 'static,
 {
     type Item = Result<(Arc<K>, Option<V>), StreamError<K, V>>;

--- a/src/stream/batch_stream.rs
+++ b/src/stream/batch_stream.rs
@@ -15,7 +15,6 @@ use crate::{
     stream::StreamError,
 };
 
-#[pin_project]
 pub(crate) struct BatchStream<K, V>
 where
     K: Encode + Decode + Send + Sync + 'static,

--- a/src/stream/batch_stream.rs
+++ b/src/stream/batch_stream.rs
@@ -15,6 +15,7 @@ use crate::{
     stream::StreamError,
 };
 
+#[pin_project]
 pub(crate) struct BatchStream<K, V>
 where
     K: Encode + Decode + Send + Sync + 'static,

--- a/src/stream/batch_stream.rs
+++ b/src/stream/batch_stream.rs
@@ -1,0 +1,69 @@
+use std::{
+    marker::PhantomData,
+    pin::{pin, Pin},
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+use arrow::record_batch::RecordBatch;
+use executor::futures::{FutureExt, Stream};
+use pin_project::pin_project;
+
+use crate::{index_batch::decode_value, serdes::Decode};
+
+#[pin_project]
+pub(crate) struct BatchStream<K, V>
+where
+    K: Decode + Send + Sync + 'static,
+    V: Decode + Send + Sync + 'static,
+{
+    pos: usize,
+    inner: RecordBatch,
+    _p: PhantomData<(K, V)>,
+}
+
+impl<K, V> BatchStream<K, V>
+where
+    K: Decode + Send + Sync + 'static,
+    V: Decode + Send + Sync + 'static,
+{
+    pub(crate) fn new(batch: RecordBatch) -> Self {
+        BatchStream {
+            pos: 0,
+            inner: batch,
+            _p: Default::default(),
+        }
+    }
+
+    async fn decode_item(&mut self) -> Result<(Arc<K>, Option<V>), V::Error> {
+        // FIXME: handle error
+        let key = decode_value::<K>(&self.inner, 0, self.pos)
+            .await
+            .unwrap()
+            .unwrap();
+        let value = decode_value::<V>(&self.inner, 1, self.pos).await?;
+
+        self.pos += 1;
+        Ok((Arc::new(key), value))
+    }
+}
+
+impl<K, V> Stream for BatchStream<K, V>
+where
+    K: Decode + Send + Sync + 'static,
+    V: Decode + Send + Sync + 'static,
+{
+    type Item = Result<(Arc<K>, Option<V>), V::Error>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        if self.pos < self.inner.num_rows() {
+            let mut future = pin!(self.decode_item());
+
+            return match future.as_mut().poll(cx) {
+                Poll::Ready(result) => Poll::Ready(Some(result)),
+                Poll::Pending => Poll::Pending,
+            };
+        }
+        Poll::Ready(None)
+    }
+}

--- a/src/stream/batch_stream.rs
+++ b/src/stream/batch_stream.rs
@@ -40,7 +40,6 @@ where
     }
 
     async fn decode_item(&mut self) -> Result<(Arc<K>, Option<V>), StreamError<K, V>> {
-        // FIXME: handle error
         let key = decode_value::<K>(&self.inner, 0, self.pos)
             .await
             .map_err(StreamError::KeyDecode)?

--- a/src/stream/buf_stream.rs
+++ b/src/stream/buf_stream.rs
@@ -61,7 +61,6 @@ impl<'a, K, V, E> Stream for BufStream<'a, K, V, E>
 where
     K: Ord + 'a,
     V: 'a,
-    E: std::error::Error + Send + Sync + 'static,
 {
     type Item = Result<(Arc<K>, Option<V>), E>;
 

--- a/src/stream/buf_stream.rs
+++ b/src/stream/buf_stream.rs
@@ -96,7 +96,6 @@ mod tests {
     use crate::stream::buf_stream::BufStream;
 
     #[test]
-
     fn iter() {
         block_on(async {
             let key_1 = Arc::new("key_1".to_owned());

--- a/src/stream/level_stream.rs
+++ b/src/stream/level_stream.rs
@@ -1,0 +1,97 @@
+use std::{
+    collections::VecDeque,
+    pin::{pin, Pin},
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+use executor::futures::Stream;
+use futures::Future;
+use pin_project::pin_project;
+use snowflake::ProcessUniqueId;
+
+use crate::{
+    serdes::{Decode, Encode},
+    stream::{table_stream::TableStream, StreamError},
+    DbOption,
+};
+
+#[pin_project]
+pub(crate) struct LevelStream<'stream, K, V>
+where
+    K: Encode + Decode + Send + Sync + 'static,
+    V: Decode + Send + Sync + 'static,
+{
+    lower: Option<Arc<K>>,
+    upper: Option<Arc<K>>,
+    option: &'stream DbOption,
+    gens: VecDeque<ProcessUniqueId>,
+    stream: Option<TableStream<'stream, K, V>>,
+}
+
+impl<'stream, K, V> LevelStream<'stream, K, V>
+where
+    K: Encode + Decode + Send + Sync + 'static,
+    V: Decode + Send + Sync + 'static,
+{
+    pub(crate) async fn new(
+        option: &'stream DbOption,
+        gens: Vec<ProcessUniqueId>,
+        lower: Option<&Arc<K>>,
+        upper: Option<&Arc<K>>,
+    ) -> Result<Self, StreamError<K, V>> {
+        let mut gens = VecDeque::from(gens);
+        let mut stream = None;
+
+        if let Some(gen) = gens.pop_front() {
+            stream = Some(TableStream::<K, V>::new(option, &gen, lower, upper).await?);
+        }
+
+        Ok(Self {
+            lower: lower.cloned(),
+            upper: upper.cloned(),
+            option,
+            gens,
+            stream,
+        })
+    }
+}
+
+impl<K, V> Stream for LevelStream<'_, K, V>
+where
+    K: Encode + Decode + Send + Sync + 'static,
+    V: Decode + Send + Sync + 'static,
+{
+    type Item = Result<(Arc<K>, Option<V>), StreamError<K, V>>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        if let Some(stream) = &mut self.stream {
+            return match Pin::new(stream).poll_next(cx) {
+                Poll::Ready(None) => match self.gens.pop_front() {
+                    None => Poll::Ready(None),
+                    Some(gen) => {
+                        let min = self.lower.clone();
+                        let max = self.upper.clone();
+                        let mut future = pin!(TableStream::<K, V>::new(
+                            self.option,
+                            &gen,
+                            min.as_ref(),
+                            max.as_ref()
+                        ));
+
+                        match future.as_mut().poll(cx) {
+                            Poll::Ready(Ok(stream)) => {
+                                self.stream = Some(stream);
+                                self.poll_next(cx)
+                            }
+                            Poll::Ready(Err(err)) => Poll::Ready(Some(Err(err))),
+                            Poll::Pending => Poll::Pending,
+                        }
+                    }
+                },
+                poll => poll,
+            };
+        }
+        Poll::Ready(None)
+    }
+}

--- a/src/stream/merge_inner_stream.rs
+++ b/src/stream/merge_inner_stream.rs
@@ -15,7 +15,6 @@ use crate::{
     utils::CmpKeyItem,
 };
 
-#[pin_project]
 pub struct MergeInnerStream<'stream, K, V>
 where
     K: Ord + Encode + Decode + Send + Sync + 'static,

--- a/src/stream/merge_inner_stream.rs
+++ b/src/stream/merge_inner_stream.rs
@@ -15,6 +15,7 @@ use crate::{
     utils::CmpKeyItem,
 };
 
+#[pin_project]
 pub struct MergeInnerStream<'stream, K, V>
 where
     K: Ord + Encode + Decode + Send + Sync + 'static,

--- a/src/stream/merge_inner_stream.rs
+++ b/src/stream/merge_inner_stream.rs
@@ -1,0 +1,94 @@
+use std::{
+    cmp::Reverse,
+    collections::BinaryHeap,
+    pin::{pin, Pin},
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+use executor::futures::{Stream, StreamExt};
+use pin_project::pin_project;
+
+use crate::{serdes::Decode, stream::EInnerStreamImpl, utils::CmpKeyItem};
+
+#[pin_project]
+pub struct MergeInnerStream<'stream, K, V>
+where
+    K: Ord + Decode + Send + Sync + 'static,
+    V: Decode + Send + Sync + 'static,
+{
+    #[allow(clippy::type_complexity)]
+    heap: BinaryHeap<Reverse<(CmpKeyItem<Arc<K>, Option<V>>, usize)>>,
+    iters: Vec<EInnerStreamImpl<'stream, K, V>>,
+    item_buf: Option<(Arc<K>, Option<V>)>,
+}
+
+impl<'stream, K, V> MergeInnerStream<'stream, K, V>
+where
+    K: Ord + Decode + Send + Sync + 'static,
+    V: Decode + Send + Sync + 'static,
+{
+    pub(crate) async fn new(
+        mut iters: Vec<EInnerStreamImpl<'stream, K, V>>,
+    ) -> Result<Self, V::Error> {
+        let mut heap = BinaryHeap::new();
+
+        for (i, iter) in iters.iter_mut().enumerate() {
+            if let Some(result) = Pin::new(iter).next().await {
+                let (key, value) = result?;
+
+                heap.push(Reverse((CmpKeyItem { key, _value: value }, i)));
+            }
+        }
+        let mut iterator = MergeInnerStream {
+            iters,
+            heap,
+            item_buf: None,
+        };
+
+        {
+            let mut iterator = pin!(&mut iterator);
+            let _ = iterator.next().await;
+        }
+
+        Ok(iterator)
+    }
+}
+
+impl<'stream, K, V> Stream for MergeInnerStream<'stream, K, V>
+where
+    K: Ord + Decode + Send + Sync + 'static,
+    V: Decode + Send + Sync + 'static,
+{
+    type Item = Result<(Arc<K>, Option<V>), V::Error>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.project();
+        while let Some(Reverse((
+            CmpKeyItem {
+                key: item_key,
+                _value: item_value,
+            },
+            idx,
+        ))) = this.heap.pop()
+        {
+            match Pin::new(&mut this.iters[idx]).poll_next(cx) {
+                Poll::Ready(Some(item)) => {
+                    let (key, value) = item?;
+                    this.heap
+                        .push(Reverse((CmpKeyItem { key, _value: value }, idx)));
+
+                    if let Some((buf_key, _)) = &this.item_buf {
+                        if buf_key == &item_key {
+                            continue;
+                        }
+                    }
+                }
+                Poll::Ready(None) => (),
+                Poll::Pending => return Poll::Pending,
+            };
+            return Poll::Ready(this.item_buf.replace((item_key, item_value)).map(Ok));
+        }
+        Poll::Ready(this.item_buf.take().map(Ok))
+    }
+}

--- a/src/stream/merge_inner_stream.rs
+++ b/src/stream/merge_inner_stream.rs
@@ -10,7 +10,7 @@ use executor::futures::{Stream, StreamExt};
 use pin_project::pin_project;
 
 use crate::{
-    serdes::Decode,
+    serdes::{Decode, Encode},
     stream::{EInnerStreamImpl, StreamError},
     utils::CmpKeyItem,
 };
@@ -18,7 +18,7 @@ use crate::{
 #[pin_project]
 pub struct MergeInnerStream<'stream, K, V>
 where
-    K: Ord + Decode + Send + Sync + 'static,
+    K: Ord + Encode + Decode + Send + Sync + 'static,
     V: Decode + Send + Sync + 'static,
 {
     #[allow(clippy::type_complexity)]
@@ -29,7 +29,7 @@ where
 
 impl<'stream, K, V> MergeInnerStream<'stream, K, V>
 where
-    K: Ord + Decode + Send + Sync + 'static,
+    K: Ord + Encode + Decode + Send + Sync + 'static,
     V: Decode + Send + Sync + 'static,
 {
     pub(crate) async fn new(
@@ -61,7 +61,7 @@ where
 
 impl<'stream, K, V> Stream for MergeInnerStream<'stream, K, V>
 where
-    K: Ord + Decode + Send + Sync + 'static,
+    K: Ord + Encode + Decode + Send + Sync + 'static,
     V: Decode + Send + Sync + 'static,
 {
     type Item = Result<(Arc<K>, Option<V>), StreamError<K, V>>;

--- a/src/stream/merge_stream.rs
+++ b/src/stream/merge_stream.rs
@@ -12,7 +12,7 @@ use futures::Stream;
 use pin_project::pin_project;
 
 use crate::{
-    serdes::Decode,
+    serdes::{Decode, Encode},
     stream::{EStreamImpl, StreamError},
     utils::CmpKeyItem,
 };
@@ -20,7 +20,7 @@ use crate::{
 #[pin_project]
 pub struct MergeStream<'stream, K, T, V, G, F>
 where
-    K: Ord + Decode,
+    K: Ord + Encode + Decode,
     T: Ord + Copy + Default,
     V: Decode + Send + Sync,
     G: Send + Sync + 'static,
@@ -34,7 +34,7 @@ where
 
 impl<'stream, K, T, V, G, F> MergeStream<'stream, K, T, V, G, F>
 where
-    K: Ord + Debug + Decode,
+    K: Ord + Debug + Encode + Decode,
     T: Ord + Copy + Default,
     V: Decode + Send + Sync,
     G: Send + Sync + 'static,
@@ -69,7 +69,7 @@ where
 
 impl<'stream, K, T, V, G, F> Stream for MergeStream<'stream, K, T, V, G, F>
 where
-    K: Ord + Debug + Decode,
+    K: Ord + Debug + Encode + Decode,
     T: Ord + Copy + Default,
     V: Decode + Send + Sync,
     G: Send + Sync + 'static,

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -12,13 +12,14 @@ use thiserror::Error;
 use crate::{
     index_batch::stream::IndexBatchStream,
     mem_table::stream::MemTableStream,
-    serdes::Decode,
-    stream::{buf_stream::BufStream, table_stream::TableStream},
+    serdes::{Decode, Encode},
+    stream::{buf_stream::BufStream, level_stream::LevelStream, table_stream::TableStream},
     transaction::TransactionStream,
 };
 
 pub(crate) mod batch_stream;
 pub(crate) mod buf_stream;
+pub(crate) mod level_stream;
 pub(crate) mod merge_inner_stream;
 pub(crate) mod merge_stream;
 pub(crate) mod table_stream;
@@ -26,7 +27,7 @@ pub(crate) mod table_stream;
 #[pin_project(project = EStreamImplProj)]
 pub(crate) enum EStreamImpl<'a, K, T, V, G, F>
 where
-    K: Ord + Decode,
+    K: Ord + Encode + Decode,
     T: Ord + Copy + Default,
     V: Decode,
     G: Send + Sync + 'static,
@@ -41,15 +42,16 @@ where
 #[pin_project(project = EInnerStreamImplProj)]
 pub(crate) enum EInnerStreamImpl<'a, K, V>
 where
-    K: Decode + Send + Sync + 'static,
+    K: Encode + Decode + Send + Sync + 'static,
     V: Decode + Send + Sync + 'static,
 {
     Table(#[pin] TableStream<'a, K, V>),
+    Level(#[pin] LevelStream<'a, K, V>),
 }
 
 impl<'a, K, T, V, G, F> Stream for EStreamImpl<'a, K, T, V, G, F>
 where
-    K: Ord + Debug + Decode,
+    K: Ord + Debug + Encode + Decode,
     T: Ord + Copy + Default,
     V: Decode + Send + Sync,
     G: Send + Sync + 'static,
@@ -69,7 +71,7 @@ where
 
 impl<'a, K, V> Stream for EInnerStreamImpl<'a, K, V>
 where
-    K: Ord + Decode + Send + Sync + 'static,
+    K: Ord + Encode + Decode + Send + Sync + 'static,
     V: Decode + Send + Sync + 'static,
 {
     type Item = Result<(Arc<K>, Option<V>), StreamError<K, V>>;
@@ -77,6 +79,7 @@ where
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         match self.project() {
             EInnerStreamImplProj::Table(stream) => stream.poll_next(cx),
+            EInnerStreamImplProj::Level(stream) => stream.poll_next(cx),
         }
     }
 }
@@ -84,13 +87,19 @@ where
 #[derive(Debug, Error)]
 pub enum StreamError<K, V>
 where
-    K: Decode,
+    K: Encode + Decode,
     V: Decode,
 {
+    #[error("compaction key encode error: {0}")]
+    KeyEncode(#[source] <K as Encode>::Error),
     #[error("compaction key decode error: {0}")]
     KeyDecode(#[source] <K as Decode>::Error),
     #[error("compaction value decode error: {0}")]
     ValueDecode(#[source] <V as Decode>::Error),
     #[error("compaction io error: {0}")]
     Io(#[source] std::io::Error),
+    #[error("compaction arrow error: {0}")]
+    Arrow(#[source] arrow::error::ArrowError),
+    #[error("compaction parquet error: {0}")]
+    Parquet(#[source] parquet::errors::ParquetError),
 }

--- a/src/stream/table_stream.rs
+++ b/src/stream/table_stream.rs
@@ -1,0 +1,163 @@
+use std::{
+    fs::File,
+    marker::PhantomData,
+    pin::{pin, Pin},
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+use arrow::{
+    array::{GenericBinaryArray, GenericByteArray, Scalar},
+    compute::kernels::cmp::{gt_eq, lt_eq},
+    datatypes::GenericBinaryType,
+};
+use executor::futures::Stream;
+use parquet::arrow::{
+    arrow_reader::{
+        ArrowPredicate, ArrowPredicateFn, ParquetRecordBatchReader,
+        ParquetRecordBatchReaderBuilder, RowFilter,
+    },
+    ProjectionMask,
+};
+use pin_project::pin_project;
+use snowflake::ProcessUniqueId;
+
+use crate::{
+    serdes::{Decode, Encode},
+    stream::batch_stream::BatchStream,
+    DbOption, Offset,
+};
+
+#[pin_project]
+pub(crate) struct TableStream<'stream, K, V>
+where
+    K: Decode + Send + Sync + 'static,
+    V: Decode + Send + Sync + 'static,
+{
+    inner: ParquetRecordBatchReader,
+    stream: BatchStream<K, V>,
+    _p: PhantomData<&'stream ()>,
+}
+
+impl<K, V> TableStream<'_, K, V>
+where
+    K: Encode + Decode + Send + Sync + 'static,
+    V: Decode + Send + Sync + 'static,
+{
+    pub(crate) async fn new(
+        option: &DbOption,
+        gen: &ProcessUniqueId,
+        lower: Option<K>,
+        upper: Option<K>,
+    ) -> Self {
+        // FIXME: unwrap
+        let file = File::open(option.table_path(gen)).unwrap();
+
+        let lower = if let Some(l) = lower {
+            Some(Self::to_scalar(l).await)
+        } else {
+            None
+        };
+        let upper = if let Some(u) = upper {
+            Some(Self::to_scalar(u).await)
+        } else {
+            None
+        };
+
+        // FIXME: Async Reader
+        let mut builder = ParquetRecordBatchReaderBuilder::try_new(file)
+            .unwrap()
+            .with_batch_size(8192);
+        let file_metadata = builder.metadata().file_metadata();
+
+        let mut predicates = Vec::with_capacity(2);
+
+        if let Some(lower_scalar) = lower {
+            predicates.push(Box::new(ArrowPredicateFn::new(
+                ProjectionMask::roots(file_metadata.schema_descr(), [0]),
+                move |record_batch| gt_eq(record_batch.column(0), &Scalar::new(&lower_scalar)),
+            )) as Box<dyn ArrowPredicate>)
+        }
+        if let Some(upper_scalar) = upper {
+            predicates.push(Box::new(ArrowPredicateFn::new(
+                ProjectionMask::roots(file_metadata.schema_descr(), [0]),
+                move |record_batch| lt_eq(record_batch.column(0), &Scalar::new(&upper_scalar)),
+            )) as Box<dyn ArrowPredicate>)
+        }
+
+        let row_filter = RowFilter::new(predicates);
+        builder = builder.with_row_filter(row_filter);
+
+        // FIXME: unwrap
+        let mut reader = builder.build().unwrap();
+        let batch = reader.next().unwrap().unwrap();
+
+        TableStream {
+            inner: reader,
+            stream: BatchStream::new(batch),
+            _p: Default::default(),
+        }
+    }
+
+    async fn to_scalar(key: K) -> GenericByteArray<GenericBinaryType<Offset>> {
+        let mut key_bytes = Vec::new();
+        key.encode(&mut key_bytes).await.unwrap();
+
+        GenericBinaryArray::<Offset>::from(vec![key_bytes.as_slice()])
+    }
+}
+
+impl<K, V> Stream for TableStream<'_, K, V>
+where
+    K: Decode + Send + Sync + 'static,
+    V: Decode + Send + Sync + 'static,
+{
+    type Item = Result<(Arc<K>, Option<V>), V::Error>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        match Pin::new(&mut self.stream).poll_next(cx) {
+            Poll::Ready(None) => {
+                match self.inner.next() {
+                    None => Poll::Ready(None),
+                    Some(result) => {
+                        // FIXME: unwrap
+                        let batch = result.unwrap();
+
+                        self.stream = BatchStream::new(batch);
+                        self.poll_next(cx)
+                    }
+                }
+            }
+            poll => poll,
+        }
+    }
+}
+
+// #[cfg(test)]
+// mod tests {
+//     use std::path::PathBuf;
+//     use executor::ExecutorBuilder;
+//     use executor::futures::StreamExt;
+//     use snowflake::ProcessUniqueId;
+//     use crate::DbOption;
+//     use crate::stream::table_stream::TableStream;
+//
+//     #[test]
+//     fn iter() {
+//         ExecutorBuilder::new().build().unwrap().block_on(async {
+//             let option = DbOption {
+//                 // TIPS: kv size in test case is 17
+//                 path: PathBuf::from("E:/test"),
+//                 max_mem_table_size: 25,
+//                 immutable_chunk_num: 1,
+//                 major_threshold_with_sst_size: 10,
+//                 level_sst_magnification: 10,
+//                 sst_file_size: 2 * 1024 * 1024,
+//             };
+//             let mut stream = TableStream::<String, String>::new(&option, &ProcessUniqueId::new(),
+// None, None).await;             while let Some(result) = stream.next().await {
+//                 println!("{}", result.unwrap().0)
+//             }
+//         })
+//     }
+// }

--- a/src/stream/table_stream.rs
+++ b/src/stream/table_stream.rs
@@ -24,7 +24,7 @@ use snowflake::ProcessUniqueId;
 
 use crate::{
     serdes::{Decode, Encode},
-    stream::batch_stream::BatchStream,
+    stream::{batch_stream::BatchStream, StreamError},
     DbOption, Offset,
 };
 
@@ -112,7 +112,7 @@ where
     K: Decode + Send + Sync + 'static,
     V: Decode + Send + Sync + 'static,
 {
-    type Item = Result<(Arc<K>, Option<V>), V::Error>;
+    type Item = Result<(Arc<K>, Option<V>), StreamError<K, V>>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         match Pin::new(&mut self.stream).poll_next(cx) {
@@ -132,32 +132,3 @@ where
         }
     }
 }
-
-// #[cfg(test)]
-// mod tests {
-//     use std::path::PathBuf;
-//     use executor::ExecutorBuilder;
-//     use executor::futures::StreamExt;
-//     use snowflake::ProcessUniqueId;
-//     use crate::DbOption;
-//     use crate::stream::table_stream::TableStream;
-//
-//     #[test]
-//     fn iter() {
-//         ExecutorBuilder::new().build().unwrap().block_on(async {
-//             let option = DbOption {
-//                 // TIPS: kv size in test case is 17
-//                 path: PathBuf::from("E:/test"),
-//                 max_mem_table_size: 25,
-//                 immutable_chunk_num: 1,
-//                 major_threshold_with_sst_size: 10,
-//                 level_sst_magnification: 10,
-//                 sst_file_size: 2 * 1024 * 1024,
-//             };
-//             let mut stream = TableStream::<String, String>::new(&option, &ProcessUniqueId::new(),
-// None, None).await;             while let Some(result) = stream.next().await {
-//                 println!("{}", result.unwrap().0)
-//             }
-//         })
-//     }
-// }

--- a/src/stream/table_stream.rs
+++ b/src/stream/table_stream.rs
@@ -126,6 +126,7 @@ where
         if self.stream.is_none() {
             return Poll::Ready(None);
         }
+        // Safety: It cannot be none here, because it has been judged above
         match Pin::new(self.stream.as_mut().unwrap()).poll_next(cx) {
             Poll::Ready(None) => match Pin::new(&mut self.inner).poll_next(cx) {
                 Poll::Ready(Some(Ok(batch))) => {

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -15,7 +15,7 @@ use thiserror::Error;
 
 use crate::{
     oracle::WriteConflict,
-    serdes::Decode,
+    serdes::{Decode, Encode},
     stream::{merge_stream::MergeStream, EStreamImpl, StreamError},
     GetWrite,
 };
@@ -23,7 +23,7 @@ use crate::{
 #[derive(Debug)]
 pub struct Transaction<K, V, DB>
 where
-    K: Ord + Decode,
+    K: Ord + Encode + Decode,
     V: Decode,
     DB: GetWrite<K, V>,
 {
@@ -34,7 +34,7 @@ where
 
 impl<K, V, DB> Transaction<K, V, DB>
 where
-    K: Hash + Ord + Debug + Decode + Send + Sync,
+    K: Hash + Ord + Debug + Encode + Decode + Send + Sync,
     V: Decode + Send + Sync,
     DB: GetWrite<K, V>,
     DB::Timestamp: Send + Sync,

--- a/src/version/cleaner.rs
+++ b/src/version/cleaner.rs
@@ -1,0 +1,67 @@
+use std::{collections::BTreeMap, fs, io, sync::Arc};
+
+use executor::futures::StreamExt;
+use futures::channel::mpsc::{channel, Receiver, Sender};
+use snowflake::ProcessUniqueId;
+
+use crate::DbOption;
+
+pub(crate) enum CleanTag {
+    Add {
+        version_num: usize,
+        gens: Vec<ProcessUniqueId>,
+    },
+    Clean {
+        version_num: usize,
+    },
+}
+
+pub(crate) struct Cleaner {
+    tag_recv: Receiver<CleanTag>,
+    gens_map: BTreeMap<usize, (Vec<ProcessUniqueId>, bool)>,
+    option: Arc<DbOption>,
+}
+
+impl Cleaner {
+    pub(crate) fn new(option: Arc<DbOption>) -> (Self, Sender<CleanTag>) {
+        let (tag_send, tag_recv) = channel(option.clean_channel_buffer);
+
+        (
+            Cleaner {
+                tag_recv,
+                gens_map: Default::default(),
+                option,
+            },
+            tag_send,
+        )
+    }
+
+    pub(crate) async fn listen(&mut self) -> Result<(), io::Error> {
+        loop {
+            match self.tag_recv.next().await {
+                None => break,
+                Some(CleanTag::Add { version_num, gens }) => {
+                    let _ = self.gens_map.insert(version_num, (gens, false));
+                }
+                Some(CleanTag::Clean { version_num }) => {
+                    if let Some((_, dropped)) = self.gens_map.get_mut(&version_num) {
+                        *dropped = true;
+                    }
+                    while let Some((first_version, (gens, dropped))) = self.gens_map.pop_first() {
+                        if !dropped {
+                            let _ = self.gens_map.insert(first_version, (gens, false));
+                            continue;
+                        }
+                        for gen in gens {
+                            fs::remove_file(self.option.table_path(&gen))?;
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+// TODO: TestCase

--- a/src/version/edit.rs
+++ b/src/version/edit.rs
@@ -16,8 +16,8 @@ pub(crate) enum VersionEdit<K>
 where
     K: Encode + Decode + Ord,
 {
-    Add { scope: Scope<K> },
-    Remove { gen: ProcessUniqueId },
+    Add { level: u8, scope: Scope<K> },
+    Remove { level: u8, gen: ProcessUniqueId },
 }
 
 impl<K> VersionEdit<K>
@@ -45,12 +45,14 @@ where
         writer: &mut W,
     ) -> Result<(), Self::Error> {
         match self {
-            VersionEdit::Add { scope } => {
+            VersionEdit::Add { scope, level } => {
                 writer.write_all(&0u8.to_le_bytes()).await?;
+                writer.write_all(&level.to_le_bytes()).await?;
                 scope.encode(writer).await?;
             }
-            VersionEdit::Remove { gen } => {
+            VersionEdit::Remove { gen, level } => {
                 writer.write_all(&1u8.to_le_bytes()).await?;
+                writer.write_all(&level.to_le_bytes()).await?;
                 writer.write_all(&bincode::serialize(gen).unwrap()).await?;
             }
         }
@@ -60,8 +62,9 @@ where
 
     fn size(&self) -> usize {
         size_of::<u8>()
+            + size_of::<u8>()
             + match self {
-                VersionEdit::Add { scope } => scope.size(),
+                VersionEdit::Add { scope, .. } => scope.size(),
                 VersionEdit::Remove { .. } => 16,
             }
     }
@@ -79,20 +82,73 @@ where
             reader.read_exact(&mut len).await?;
             u8::from_le_bytes(len) as usize
         };
+        let level = {
+            let mut level = [0; size_of::<u8>()];
+            reader.read_exact(&mut level).await?;
+            u8::from_le_bytes(level)
+        };
 
         Ok(match edit_type {
-            0 => VersionEdit::Add {
-                scope: Scope::<K>::decode(reader).await?,
-            },
+            0 => {
+                let scope = Scope::<K>::decode(reader).await?;
+
+                VersionEdit::Add { level, scope }
+            }
             1 => {
                 let gen = {
                     let mut slice = [0; 16];
                     reader.read_exact(&mut slice).await?;
                     bincode::deserialize(&slice).unwrap()
                 };
-                VersionEdit::Remove { gen }
+                VersionEdit::Remove { level, gen }
             }
             _ => todo!(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use futures::{executor::block_on, io::Cursor};
+
+    use crate::{scope::Scope, serdes::Encode, version::edit::VersionEdit};
+
+    #[test]
+    fn encode_and_decode() {
+        block_on(async {
+            let edits = vec![
+                VersionEdit::Add {
+                    level: 0,
+                    scope: Scope {
+                        min: Arc::new("Min".to_string()),
+                        max: Arc::new("Max".to_string()),
+                        gen: Default::default(),
+                    },
+                },
+                VersionEdit::Remove {
+                    level: 1,
+                    gen: Default::default(),
+                },
+            ];
+
+            let bytes = {
+                let mut cursor = Cursor::new(vec![]);
+
+                for edit in edits.clone() {
+                    edit.encode(&mut cursor).await.unwrap();
+                }
+                cursor.into_inner()
+            };
+
+            let decode_edits = {
+                let mut cursor = Cursor::new(bytes);
+
+                VersionEdit::<String>::recover(&mut cursor).await
+            };
+
+            assert_eq!(edits, decode_edits);
         })
     }
 }

--- a/src/version/mod.rs
+++ b/src/version/mod.rs
@@ -41,7 +41,7 @@ where
 {
     pub(crate) num: usize,
     pub(crate) level_slice: [Vec<Scope<K>>; MAX_LEVEL],
-    clean_sender: Sender<CleanTag>,
+    pub(crate) clean_sender: Sender<CleanTag>,
 }
 
 impl<K> Clone for Version<K>

--- a/src/version/mod.rs
+++ b/src/version/mod.rs
@@ -1,7 +1,7 @@
 pub(crate) mod edit;
 
 use std::{
-    fs::{metadata, File, OpenOptions},
+    fs::{File, OpenOptions},
     io::SeekFrom,
     sync::Arc,
 };
@@ -187,12 +187,10 @@ pub(crate) async fn apply_edits<K: Encode + Decode + Ord>(
 #[derive(Debug, Error)]
 pub enum VersionError<K>
 where
-    K: Encode + Decode,
+    K: Encode,
 {
     #[error("version encode error: {0}")]
     Encode(#[source] <K as Encode>::Error),
-    #[error("version decode error: {0}")]
-    Decode(#[source] <K as Decode>::Error),
     #[error("version io error: {0}")]
     Io(#[source] std::io::Error),
     #[error("version arrow error: {0}")]

--- a/src/version/set.rs
+++ b/src/version/set.rs
@@ -1,0 +1,109 @@
+use std::{fs::OpenOptions, io::SeekFrom, sync::Arc};
+
+use async_lock::RwLock;
+use executor::{
+    fs,
+    futures::{AsyncSeekExt, AsyncWriteExt},
+};
+
+use crate::{
+    serdes::{Decode, Encode},
+    version::{edit::VersionEdit, Version, VersionError, VersionRef},
+    DbOption,
+};
+
+pub(crate) struct VersionSetInner<K>
+where
+    K: Encode + Decode + Ord,
+{
+    current: VersionRef<K>,
+    log: fs::File,
+}
+
+pub(crate) struct VersionSet<K>
+where
+    K: Encode + Decode + Ord,
+{
+    inner: Arc<RwLock<VersionSetInner<K>>>,
+}
+
+impl<K> Clone for VersionSet<K>
+where
+    K: Encode + Decode + Ord,
+{
+    fn clone(&self) -> Self {
+        VersionSet {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+impl<K> VersionSet<K>
+where
+    K: Encode + Decode + Ord,
+{
+    pub(crate) async fn new(option: &DbOption) -> Result<Self, VersionError<K>> {
+        let mut log = fs::File::from(
+            OpenOptions::new()
+                .create(true)
+                .write(true)
+                .read(true)
+                .open(option.version_path())
+                .map_err(VersionError::Io)?,
+        );
+        let edits = VersionEdit::recover(&mut log).await;
+        log.seek(SeekFrom::End(0)).await.map_err(VersionError::Io)?;
+
+        let set = VersionSet::<K> {
+            inner: Arc::new(RwLock::new(VersionSetInner {
+                current: Arc::new(Version {
+                    num: 0,
+                    level_slice: Version::level_slice_new(),
+                }),
+                log,
+            })),
+        };
+        set.apply_edits(edits, true).await?;
+
+        Ok(set)
+    }
+
+    pub(crate) async fn current(&self) -> VersionRef<K> {
+        self.inner.read().await.current.clone()
+    }
+
+    pub(crate) async fn apply_edits(
+        &self,
+        version_edits: Vec<VersionEdit<K>>,
+        is_recover: bool,
+    ) -> Result<(), VersionError<K>> {
+        let mut guard = self.inner.write().await;
+
+        let mut new_version = Version::clone(&guard.current);
+
+        for version_edit in version_edits {
+            if !is_recover {
+                version_edit
+                    .encode(&mut guard.log)
+                    .await
+                    .map_err(VersionError::Encode)?;
+            }
+            match version_edit {
+                VersionEdit::Add { scope, level } => {
+                    new_version.level_slice[level as usize].push(scope);
+                }
+                VersionEdit::Remove { gen, level } => {
+                    if let Some(i) = new_version.level_slice[level as usize]
+                        .iter()
+                        .position(|scope| scope.gen == gen)
+                    {
+                        new_version.level_slice[level as usize].remove(i);
+                    }
+                }
+            }
+        }
+        guard.log.flush().await.map_err(VersionError::Io)?;
+        guard.current = Arc::new(new_version);
+        Ok(())
+    }
+}


### PR DESCRIPTION
compaction: 
- Implemented 7 levels of leveled compaction, when querying, a full scan is performed at Level 0, and a binary query is performed at Levels 1-6.

mvcc:
- Use VersionSet to keep the latest Version

todo: 
- [ ] Stream unification
- [x] Level Stream
- [ ] Transaction supports Version