### PR TITLE
Feat/wal clean

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,4 @@
-workspace = { members = [ "src/benchs","src/elsm_marco"] }
+workspace = { members = [ "src/benches","src/elsm_marco"] }
 [package]
 edition = "2021"
 name = "elsm"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ bincode = "1"
 crc32fast = "1"
 crossbeam-queue = "0.3"
 elsm_marco = { path = "src/elsm_marco" }
-executor = { git = "https://github.com/ethe/executor.git", branch = "main" }
 futures = "0.3"
 fxhash = "0.2"
 itertools = "0.13"
@@ -25,6 +24,7 @@ pin-project = "1"
 pin-project-lite = "0.2"
 regex = "1"
 thiserror = "1"
+tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 ulid = "1"
 unsend = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ elsm_marco = { path = "src/elsm_marco" }
 executor = { git = "https://github.com/ethe/executor.git", branch = "main" }
 futures = "0.3"
 fxhash = "0.2"
+itertools = "0.13"
 # replace them with std::sync::lazy, once stabilized
 lazy_static = "1"
 once_cell = "1"
@@ -23,9 +24,9 @@ parquet = { version = "51", features = ["async"] }
 pin-project = "1"
 pin-project-lite = "0.2"
 regex = "1"
-snowflake = { version = "1", features = ["serde_support"] }
 thiserror = "1"
 tracing = "0.1"
+ulid = "1"
 unsend = "0.2"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,4 @@
-workspace = { members = ["src/elsm_marco"] }
+workspace = { members = [ "src/benchs","src/elsm_marco"] }
 [package]
 edition = "2021"
 name = "elsm"

--- a/src/benches/Cargo.toml
+++ b/src/benches/Cargo.toml
@@ -15,8 +15,8 @@ pprof = { version = "0.13", features = ["criterion", "flamegraph"] }
 
 [dependencies]
 arrow = "51"
-criterion = { version = "0.3", features = ["async_tokio", "html_reports"] }
-elsm = { path = "../../../eelsm" }
+criterion = { version = "0.5", features = ["async_tokio", "html_reports"] }
+elsm = { path = "../../../elsm" }
 elsm_marco = { path = "../elsm_marco" }
 itertools = "0.13"
 lazy_static = "1"

--- a/src/benches/Cargo.toml
+++ b/src/benches/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "benchs"
+name = "benches"
 version = "0.1.0"
 edition = "2021"
 
@@ -11,12 +11,12 @@ path = "src/main.rs"
 harness = false
 
 [target.'cfg(unix)'.dependencies]
-pprof = { version = "0.13", features = ["criterion"] }
+pprof = { version = "0.13", features = ["criterion", "flamegraph"] }
 
 [dependencies]
 arrow = "51"
 criterion = { version = "0.3", features = ["async_tokio", "html_reports"] }
-elsm = { path = "../../../elsm" }
+elsm = { path = "../../../eelsm" }
 elsm_marco = { path = "../elsm_marco" }
 itertools = "0.13"
 lazy_static = "1"

--- a/src/benches/Cargo.toml
+++ b/src/benches/Cargo.toml
@@ -10,6 +10,9 @@ name = "benchmark"
 path = "src/main.rs"
 harness = false
 
+[profile.release]
+strip = "debuginfo"
+
 [target.'cfg(unix)'.dependencies]
 pprof = { version = "0.13", features = ["criterion", "flamegraph"] }
 

--- a/src/benches/src/main.rs
+++ b/src/benches/src/main.rs
@@ -232,7 +232,7 @@ fn elsm_empty_opens(c: &mut Criterion) {
 criterion_group!(
     name = benches;
     config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
-    targets = bench,
+    targets = elsm_bulk_load, elsm_monotonic_crud, elsm_random_crud, elsm_empty_opens
     elsm_bulk_load,
     elsm_monotonic_crud,
     elsm_random_crud,

--- a/src/benches/src/main.rs
+++ b/src/benches/src/main.rs
@@ -10,8 +10,6 @@ use arrow::{
     datatypes::{DataType, Field, Fields, SchemaRef},
     record_batch::RecordBatch,
 };
-#[cfg(unix)]
-use pprof::criterion::{PProfProfiler, Output};
 use criterion::{criterion_group, criterion_main, Criterion};
 use elsm::{
     oracle::LocalOracle,
@@ -24,6 +22,8 @@ use elsm::{
 use elsm_marco::elsm_schema;
 use itertools::Itertools;
 use lazy_static::lazy_static;
+#[cfg(unix)]
+use pprof::criterion::{Output, PProfProfiler};
 use rand::{distributions::Alphanumeric, rngs::StdRng, Rng, SeedableRng};
 use tokio::{
     io,
@@ -75,7 +75,7 @@ fn random(n: u32) -> u32 {
 fn elsm_bulk_load(c: &mut Criterion) {
     let count = AtomicU32::new(0_u32);
     let bytes = |len| -> String {
-        let mut r = StdRng::seed_from_u64(count as u64);
+        let mut r = StdRng::seed_from_u64(count.fetch_add(1, Ordering::Relaxed) as u64);
 
         r.sample_iter(&Alphanumeric)
             .take(len)
@@ -240,6 +240,7 @@ criterion_group!(
 );
 #[cfg(windows)]
 criterion_group!(
+    benches,
     elsm_bulk_load,
     elsm_monotonic_crud,
     elsm_random_crud,

--- a/src/benches/src/main.rs
+++ b/src/benches/src/main.rs
@@ -198,7 +198,7 @@ fn elsm_random_crud(c: &mut Criterion) {
 
     c.bench_function("random gets", |b| {
         b.to_async(&rt).iter(|| async {
-            db.get(&random(SIZE), &0).await.unwrap();
+            let _ = db.get(&random(SIZE), &0).await;
         })
     });
 

--- a/src/benches/src/main.rs
+++ b/src/benches/src/main.rs
@@ -20,7 +20,6 @@ use elsm::{
     Db, DbOption,
 };
 use elsm_marco::elsm_schema;
-use itertools::Itertools;
 use lazy_static::lazy_static;
 #[cfg(unix)]
 use pprof::criterion::{Output, PProfProfiler};
@@ -75,7 +74,7 @@ fn random(n: u32) -> u32 {
 fn elsm_bulk_load(c: &mut Criterion) {
     let count = AtomicU32::new(0_u32);
     let bytes = |len| -> String {
-        let mut r = StdRng::seed_from_u64(count.fetch_add(1, Ordering::Relaxed) as u64);
+        let r = StdRng::seed_from_u64(count.fetch_add(1, Ordering::Relaxed) as u64);
 
         r.sample_iter(&Alphanumeric)
             .take(len)
@@ -230,13 +229,10 @@ fn elsm_empty_opens(c: &mut Criterion) {
 }
 #[cfg(unix)]
 criterion_group!(
+    benches
     name = benches;
     config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
     targets = elsm_bulk_load, elsm_monotonic_crud, elsm_random_crud, elsm_empty_opens
-    elsm_bulk_load,
-    elsm_monotonic_crud,
-    elsm_random_crud,
-    elsm_empty_opens
 );
 #[cfg(windows)]
 criterion_group!(

--- a/src/benchs/Cargo.toml
+++ b/src/benchs/Cargo.toml
@@ -10,6 +10,9 @@ name = "benchmark"
 path = "src/main.rs"
 harness = false
 
+[target.'cfg(unix)'.dependencies]
+pprof = { version = "0.13", features = ["criterion"] }
+
 [dependencies]
 arrow = "51"
 criterion = { version = "0.3", features = ["async_tokio", "html_reports"] }

--- a/src/benchs/Cargo.toml
+++ b/src/benchs/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "benchs"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[[bench]]
+name = "benchmark"
+path = "src/main.rs"
+harness = false
+
+[dependencies]
+arrow = "51"
+criterion = { version = "0.3", features = ["async"] }
+elsm = { path = "../../../elsm" }
+elsm_marco = { path = "../elsm_marco" }
+executor = { git = "https://github.com/ethe/executor.git", rev = "279fc08d7ba72b9ab8cfd73518f821ecc4956fae" }
+itertools = "0.13"
+lazy_static = "1"

--- a/src/benchs/Cargo.toml
+++ b/src/benchs/Cargo.toml
@@ -13,7 +13,7 @@ harness = false
 [dependencies]
 arrow = "51"
 criterion = { version = "0.3", features = ["async_tokio", "html_reports"] }
-elsm = { path = "../../../eelsm" }
+elsm = { path = "../../../elsm" }
 elsm_marco = { path = "../elsm_marco" }
 itertools = "0.13"
 lazy_static = "1"

--- a/src/benchs/Cargo.toml
+++ b/src/benchs/Cargo.toml
@@ -12,9 +12,10 @@ harness = false
 
 [dependencies]
 arrow = "51"
-criterion = { version = "0.3", features = ["async"] }
-elsm = { path = "../../../elsm" }
+criterion = { version = "0.3", features = ["async_tokio", "html_reports"] }
+elsm = { path = "../../../eelsm" }
 elsm_marco = { path = "../elsm_marco" }
-executor = { git = "https://github.com/ethe/executor.git", rev = "279fc08d7ba72b9ab8cfd73518f821ecc4956fae" }
 itertools = "0.13"
 lazy_static = "1"
+rand = "0.8"
+tokio = { version = "1", features = ["full"] }

--- a/src/benchs/src/main.rs
+++ b/src/benchs/src/main.rs
@@ -21,7 +21,7 @@ use elsm::{
 };
 use elsm_marco::elsm_schema;
 use executor::{
-    futures::{future::block_on, io, AsyncRead, AsyncWrite},
+    futures::{future::block_on, io},
     ExecutorBuilder,
 };
 use itertools::Itertools;

--- a/src/benchs/src/main.rs
+++ b/src/benchs/src/main.rs
@@ -1,0 +1,229 @@
+use std::sync::{
+    atomic::{AtomicU32, Ordering},
+    Arc,
+};
+
+use arrow::{
+    array::{
+        Array, StringArray, StringBuilder, StructArray, StructBuilder, UInt32Array, UInt32Builder,
+    },
+    datatypes::{DataType, Field, Fields, SchemaRef},
+    record_batch::RecordBatch,
+};
+use criterion::{criterion_group, criterion_main, Criterion};
+use elsm::{
+    oracle::LocalOracle,
+    record::RecordType,
+    schema::{Builder, Schema},
+    serdes::{Decode, Encode},
+    wal::provider::in_mem::InMemProvider,
+    Db, DbOption,
+};
+use elsm_marco::elsm_schema;
+use executor::{
+    futures::{future::block_on, io, AsyncRead, AsyncWrite},
+    ExecutorBuilder,
+};
+use itertools::Itertools;
+use lazy_static::lazy_static;
+
+fn counter() -> usize {
+    use std::sync::atomic::{AtomicUsize, Ordering::Relaxed};
+
+    static C: AtomicUsize = AtomicUsize::new(0);
+
+    C.fetch_add(1, Relaxed)
+}
+
+#[derive(Debug, Eq, PartialEq)]
+#[elsm_schema]
+pub(crate) struct TestString {
+    #[primary_key]
+    pub(crate) string_0: String,
+    pub(crate) string_1: String,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+#[elsm_schema]
+pub(crate) struct User {
+    #[primary_key]
+    pub(crate) id: u32,
+    pub(crate) i_number_0: u32,
+}
+
+fn random(n: u32) -> u32 {
+    use std::{cell::Cell, num::Wrapping};
+
+    thread_local! {
+        static RNG: Cell<Wrapping<u32>> = Cell::new(Wrapping(1406868647));
+    }
+
+    RNG.with(|rng| {
+        let mut x = rng.get();
+        x ^= x << 13;
+        x ^= x >> 17;
+        x ^= x << 5;
+        rng.set(x);
+
+        ((x.0 as u64).wrapping_mul(n as u64) >> 32) as u32
+    })
+}
+
+fn elsm_bulk_load(c: &mut Criterion) {
+    let count = AtomicU32::new(0_u32);
+    let bytes = |len| -> String {
+        String::from_utf8(
+            count
+                .fetch_add(1, Ordering::Relaxed)
+                .to_be_bytes()
+                .into_iter()
+                .cycle()
+                .take(len)
+                .collect_vec(),
+        )
+        .unwrap()
+    };
+
+    let mut bench = |key_len, val_len| {
+        let db = block_on(async {
+            Db::new(
+                LocalOracle::default(),
+                InMemProvider::default(),
+                DbOption::new(format!("monotonic_crud/{}/", counter())),
+            )
+            .await
+            .unwrap()
+        });
+
+        c.bench_function(
+            &format!("bulk load key/value lengths {}/{}", key_len, val_len),
+            |b| {
+                b.to_async(ExecutorBuilder::new().build().unwrap())
+                    .iter(|| async {
+                        db.write(
+                            RecordType::Full,
+                            0,
+                            TestStringInner::new(bytes(key_len), bytes(val_len)),
+                        )
+                        .await
+                        .unwrap();
+                    })
+            },
+        );
+    };
+
+    for key_len in &[10_usize, 128, 256, 512] {
+        for val_len in &[0_usize, 10, 128, 256, 512, 1024, 2048, 4096, 8192] {
+            bench(*key_len, *val_len)
+        }
+    }
+}
+
+fn elsm_monotonic_crud(c: &mut Criterion) {
+    let db = block_on(async {
+        Db::new(
+            LocalOracle::default(),
+            InMemProvider::default(),
+            DbOption::new(format!("monotonic_crud/{}/", counter())),
+        )
+        .await
+        .unwrap()
+    });
+
+    c.bench_function("monotonic inserts", |b| {
+        let count = AtomicU32::new(0_u32);
+        b.to_async(ExecutorBuilder::new().build().unwrap())
+            .iter(|| async {
+                let count = count.fetch_add(1, Ordering::Relaxed);
+                db.write(RecordType::Full, 0, UserInner::new(count, count))
+                    .await
+                    .unwrap();
+            })
+    });
+
+    c.bench_function("monotonic gets", |b| {
+        let count = AtomicU32::new(0_u32);
+        b.to_async(ExecutorBuilder::new().build().unwrap())
+            .iter(|| async {
+                let count = count.fetch_add(1, Ordering::Relaxed);
+                db.get(&count, &0).await.unwrap();
+            })
+    });
+
+    c.bench_function("monotonic removals", |b| {
+        let count = AtomicU32::new(0_u32);
+        b.to_async(ExecutorBuilder::new().build().unwrap())
+            .iter(|| async {
+                let count = count.fetch_add(1, Ordering::Relaxed);
+                db.remove(RecordType::Full, 0, count).await.unwrap();
+            })
+    });
+}
+
+fn elsm_random_crud(c: &mut Criterion) {
+    const SIZE: u32 = 65536;
+
+    let db = block_on(async {
+        Db::new(
+            LocalOracle::default(),
+            InMemProvider::default(),
+            DbOption::new(format!("random_crud/{}/", counter())),
+        )
+        .await
+        .unwrap()
+    });
+
+    c.bench_function("random inserts", |b| {
+        b.to_async(ExecutorBuilder::new().build().unwrap())
+            .iter(|| async {
+                db.write(
+                    RecordType::Full,
+                    0,
+                    UserInner::new(random(SIZE), random(SIZE)),
+                )
+                .await
+                .unwrap();
+            })
+    });
+
+    c.bench_function("random gets", |b| {
+        b.to_async(ExecutorBuilder::new().build().unwrap())
+            .iter(|| async {
+                db.get(&random(SIZE), &0).await.unwrap();
+            })
+    });
+
+    c.bench_function("random removals", |b| {
+        b.to_async(ExecutorBuilder::new().build().unwrap())
+            .iter(|| async {
+                db.remove(RecordType::Full, 0, random(SIZE)).await.unwrap();
+            })
+    });
+}
+
+fn elsm_empty_opens(c: &mut Criterion) {
+    let _ = std::fs::remove_dir_all("empty_opens");
+
+    c.bench_function("empty opens", |b| {
+        b.to_async(ExecutorBuilder::new().build().unwrap())
+            .iter(|| async {
+                Db::<UserInner, LocalOracle<<UserInner as Schema>::PrimaryKey>, InMemProvider>::new(
+                    LocalOracle::default(),
+                    InMemProvider::default(),
+                    DbOption::new(format!("empty_opens/{}/", counter())),
+                )
+                .await
+                .unwrap()
+            })
+    });
+    let _ = std::fs::remove_dir_all("empty_opens");
+}
+
+criterion_group!(
+    benches,
+    elsm_bulk_load,
+    elsm_monotonic_crud,
+    elsm_random_crud,
+    elsm_empty_opens
+);
+criterion_main!(benches);

--- a/src/benchs/src/main.rs
+++ b/src/benchs/src/main.rs
@@ -150,7 +150,7 @@ fn elsm_monotonic_crud(c: &mut Criterion) {
         let count = AtomicU32::new(0_u32);
         b.to_async(&rt).iter(|| async {
             let count = count.fetch_add(1, Ordering::Relaxed);
-            db.get(&count, &0).await.unwrap();
+            let _ = db.get(&count, &0).await;
         })
     });
 

--- a/src/elsm_marco/src/keys.rs
+++ b/src/elsm_marco/src/keys.rs
@@ -7,6 +7,7 @@ pub(crate) struct PrimaryKey {
     pub(crate) base_ty: Type,
     pub(crate) array_ty: TokenStream,
     pub(crate) builder_ty: TokenStream,
+    pub(crate) is_string: bool,
 }
 
 #[derive(Clone)]

--- a/src/index_batch/mod.rs
+++ b/src/index_batch/mod.rs
@@ -54,94 +54,90 @@ where
 
 #[cfg(test)]
 mod tests {
-    use executor::ExecutorBuilder;
-
     use crate::{
         mem_table::MemTable, oracle::LocalOracle, tests::UserInner,
         wal::provider::in_mem::InMemProvider, Db,
     };
 
-    #[test]
-    fn find() {
-        ExecutorBuilder::new().build().unwrap().block_on(async {
-            let mut mem_table = MemTable::default();
+    #[tokio::test]
+    async fn find() {
+        let mut mem_table = MemTable::default();
 
-            mem_table.insert(
+        mem_table.insert(
+            1,
+            0,
+            Some(UserInner::new(
                 1,
+                "1".to_string(),
+                false,
                 0,
-                Some(UserInner::new(
-                    1,
-                    "1".to_string(),
-                    false,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                )),
-            );
-            mem_table.insert(1, 1, None);
-            mem_table.insert(
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+            )),
+        );
+        mem_table.insert(1, 1, None);
+        mem_table.insert(
+            2,
+            0,
+            Some(UserInner::new(
                 2,
+                "2".to_string(),
+                false,
                 0,
-                Some(UserInner::new(
-                    2,
-                    "2".to_string(),
-                    false,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                )),
-            );
-            mem_table.insert(3, 0, None);
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+            )),
+        );
+        mem_table.insert(3, 0, None);
 
-            let batch = Db::<UserInner, LocalOracle<u64>, InMemProvider>::freeze(mem_table)
-                .await
-                .unwrap();
+        let batch = Db::<UserInner, LocalOracle<u64>, InMemProvider>::freeze(mem_table)
+            .await
+            .unwrap();
 
-            assert_eq!(
-                batch.find(&1, &0).await,
-                Some(Some(UserInner::new(
-                    1,
-                    "1".to_string(),
-                    false,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0
-                )))
-            );
-            assert_eq!(batch.find(&1, &1).await, Some(None));
+        assert_eq!(
+            batch.find(&1, &0).await,
+            Some(Some(UserInner::new(
+                1,
+                "1".to_string(),
+                false,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0
+            )))
+        );
+        assert_eq!(batch.find(&1, &1).await, Some(None));
 
-            assert_eq!(
-                batch.find(&2, &0).await,
-                Some(Some(UserInner::new(
-                    2,
-                    "2".to_string(),
-                    false,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0
-                )))
-            );
-            assert_eq!(batch.find(&3, &0).await, Some(None));
-        });
+        assert_eq!(
+            batch.find(&2, &0).await,
+            Some(Some(UserInner::new(
+                2,
+                "2".to_string(),
+                false,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0
+            )))
+        );
+        assert_eq!(batch.find(&3, &0).await, Some(None));
     }
 }

--- a/src/index_batch/stream.rs
+++ b/src/index_batch/stream.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use arrow::array::RecordBatch;
-use executor::futures::{Stream, StreamExt};
+use futures::{Stream, StreamExt};
 use pin_project::pin_project;
 
 use crate::{
@@ -98,8 +98,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use executor::futures::StreamExt;
-    use futures::executor::block_on;
+    use futures::{executor::block_on, StreamExt};
 
     use crate::{
         mem_table::MemTable, oracle::LocalOracle, tests::UserInner,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -543,10 +543,10 @@ impl DbOption {
         DbOption {
             path: path.into(),
             max_mem_table_size: 8 * 1024 * 1024,
-            immutable_chunk_num: 5,
+            immutable_chunk_num: 3,
             major_threshold_with_sst_size: 10,
             level_sst_magnification: 10,
-            max_sst_file_size: 64 * 1024 * 1024,
+            max_sst_file_size: 24 * 1024 * 1024,
             clean_channel_buffer: 10,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ use std::{
     collections::{BTreeMap, VecDeque},
     error,
     fmt::Debug,
+    fs,
     future::Future,
     io, mem,
     path::PathBuf,
@@ -113,6 +114,8 @@ where
         wal_provider: WP,
         option: DbOption,
     ) -> Result<Self, WriteError<<Record<S::PrimaryKey, S> as Encode>::Error>> {
+        fs::create_dir_all(&option.path).unwrap();
+
         let wal_manager = Arc::new(WalManager::new(wal_provider));
         let mutable_shards = RwLock::new(MutableShard {
             mutable: MemTable::default(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,7 +128,7 @@ where
         let version_set =
             VersionSet::<S, WP>::new(&option, clean_sender.clone(), wal_manager.clone())
                 .await
-                .unwrap();
+                .map_err(|err| WriteError::Internal(Box::new(err)))?;
         let mut compactor =
             Compactor::<S, WP>::new(immutable.clone(), option.clone(), version_set.clone());
 

--- a/src/mem_table/mod.rs
+++ b/src/mem_table/mod.rs
@@ -130,7 +130,7 @@ where
 
     pub(crate) fn insert(&mut self, key: S::PrimaryKey, ts: TimeStamp, value: Option<S>) {
         self.max_ts = cmp::max(self.max_ts, ts);
-        self.written_size = key.size() + ts.size() + value.as_ref().map(Encode::size).unwrap_or(0);
+        self.written_size += key.size() + value.as_ref().map(Encode::size).unwrap_or(0);
 
         let _ = self.data.insert(InternalKey { key, ts }, value);
     }

--- a/src/mem_table/mod.rs
+++ b/src/mem_table/mod.rs
@@ -158,7 +158,7 @@ mod tests {
     use crate::{
         record::{Record, RecordType},
         tests::UserInner,
-        wal::{WalFile, WalWrite},
+        wal::{FileId, WalFile, WalWrite},
     };
 
     #[test]
@@ -330,14 +330,14 @@ mod tests {
         let value = UserInner::new(0, "v".to_string(), false, 0, 0, 0, 0, 0, 0, 0, 0);
         block_on(async {
             {
-                let mut wal = WalFile::new(Cursor::new(&mut file));
+                let mut wal = WalFile::new(Cursor::new(&mut file), FileId::new());
                 wal.write(Record::new(RecordType::Full, &key, 0, Some(&value)))
                     .await
                     .unwrap();
                 wal.flush().await.unwrap();
             }
             {
-                let mut wal = WalFile::new(Cursor::new(&mut file));
+                let mut wal = WalFile::new(Cursor::new(&mut file), FileId::new());
                 let mem_table: MemTable<UserInner> = MemTable::from_wal(&mut wal).await.unwrap();
                 assert_eq!(mem_table.get(&key, &0), Some(Some(&value)));
             }

--- a/src/mem_table/mod.rs
+++ b/src/mem_table/mod.rs
@@ -152,7 +152,9 @@ where
 
 #[cfg(test)]
 mod tests {
-    use futures::{executor::block_on, io::Cursor};
+    use std::io::Cursor;
+
+    use futures::executor::block_on;
 
     use super::MemTable;
     use crate::{

--- a/src/mem_table/stream.rs
+++ b/src/mem_table/stream.rs
@@ -4,7 +4,7 @@ use std::{
     task::{Context, Poll},
 };
 
-use executor::futures::{util::StreamExt, Stream};
+use futures::{Stream, StreamExt};
 use pin_project::pin_project;
 
 use crate::{
@@ -108,34 +108,72 @@ where
 
 #[cfg(test)]
 mod tests {
-    use executor::futures::{future::block_on, StreamExt};
+    use futures::StreamExt;
 
     use crate::{mem_table::MemTable, tests::UserInner};
 
-    #[test]
-    fn iterator() {
-        block_on(async {
-            let mut mem_table = MemTable::default();
+    #[tokio::test]
+    async fn iterator() {
+        let mut mem_table = MemTable::default();
 
-            mem_table.insert(
+        mem_table.insert(
+            1,
+            0,
+            Some(UserInner::new(
                 1,
+                "1".to_string(),
+                false,
                 0,
-                Some(UserInner::new(
-                    1,
-                    "1".to_string(),
-                    false,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                )),
-            );
-            mem_table.insert(
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+            )),
+        );
+        mem_table.insert(
+            1,
+            1,
+            Some(UserInner::new(
+                2,
+                "2".to_string(),
+                false,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+            )),
+        );
+
+        mem_table.insert(
+            2,
+            0,
+            Some(UserInner::new(
                 1,
+                "1".to_string(),
+                false,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+            )),
+        );
+
+        let mut iterator = mem_table.iter().await.unwrap();
+
+        assert_eq!(
+            iterator.next().await.unwrap().unwrap(),
+            (
                 1,
                 Some(UserInner::new(
                     2,
@@ -148,13 +186,14 @@ mod tests {
                     0,
                     0,
                     0,
-                    0,
-                )),
-            );
-
-            mem_table.insert(
+                    0
+                ))
+            )
+        );
+        assert_eq!(
+            iterator.next().await.unwrap().unwrap(),
+            (
                 2,
-                0,
                 Some(UserInner::new(
                     1,
                     "1".to_string(),
@@ -166,68 +205,115 @@ mod tests {
                     0,
                     0,
                     0,
-                    0,
-                )),
-            );
+                    0
+                ))
+            )
+        );
 
-            let mut iterator = mem_table.iter().await.unwrap();
+        drop(iterator);
+        mem_table.insert(1, 3, None);
 
-            assert_eq!(
-                iterator.next().await.unwrap().unwrap(),
-                (
-                    1,
-                    Some(UserInner::new(
-                        2,
-                        "2".to_string(),
-                        false,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0
-                    ))
-                )
-            );
-            assert_eq!(
-                iterator.next().await.unwrap().unwrap(),
-                (
-                    2,
-                    Some(UserInner::new(
-                        1,
-                        "1".to_string(),
-                        false,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0
-                    ))
-                )
-            );
+        let mut iterator = mem_table.iter().await.unwrap();
 
-            drop(iterator);
-            mem_table.insert(1, 3, None);
-
-            let mut iterator = mem_table.iter().await.unwrap();
-
-            assert_eq!(iterator.next().await.unwrap().unwrap(), (1, None));
-        });
+        assert_eq!(iterator.next().await.unwrap().unwrap(), (1, None));
     }
 
-    #[test]
-    fn range() {
-        futures::executor::block_on(async {
-            let mut mem_table = MemTable::default();
+    #[tokio::test]
+    async fn range() {
+        let mut mem_table = MemTable::default();
 
-            mem_table.insert(
+        mem_table.insert(
+            1,
+            0,
+            Some(UserInner::new(
                 1,
+                "1".to_string(),
+                false,
                 0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+            )),
+        );
+        mem_table.insert(
+            2,
+            0,
+            Some(UserInner::new(
+                2,
+                "2".to_string(),
+                false,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+            )),
+        );
+        mem_table.insert(
+            2,
+            1,
+            Some(UserInner::new(
+                3,
+                "3".to_string(),
+                false,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+            )),
+        );
+        mem_table.insert(
+            3,
+            0,
+            Some(UserInner::new(
+                3,
+                "3".to_string(),
+                false,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+            )),
+        );
+        mem_table.insert(
+            4,
+            0,
+            Some(UserInner::new(
+                4,
+                "4".to_string(),
+                false,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+            )),
+        );
+
+        let mut iterator = mem_table.iter().await.unwrap();
+
+        assert_eq!(
+            iterator.next().await.unwrap().unwrap(),
+            (
+                1,
                 Some(UserInner::new(
                     1,
                     "1".to_string(),
@@ -239,29 +325,14 @@ mod tests {
                     0,
                     0,
                     0,
-                    0,
-                )),
-            );
-            mem_table.insert(
+                    0
+                ))
+            )
+        );
+        assert_eq!(
+            iterator.next().await.unwrap().unwrap(),
+            (
                 2,
-                0,
-                Some(UserInner::new(
-                    2,
-                    "2".to_string(),
-                    false,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                )),
-            );
-            mem_table.insert(
-                2,
-                1,
                 Some(UserInner::new(
                     3,
                     "3".to_string(),
@@ -273,12 +344,14 @@ mod tests {
                     0,
                     0,
                     0,
-                    0,
-                )),
-            );
-            mem_table.insert(
+                    0
+                ))
+            )
+        );
+        assert_eq!(
+            iterator.next().await.unwrap().unwrap(),
+            (
                 3,
-                0,
                 Some(UserInner::new(
                     3,
                     "3".to_string(),
@@ -290,12 +363,14 @@ mod tests {
                     0,
                     0,
                     0,
-                    0,
-                )),
-            );
-            mem_table.insert(
+                    0
+                ))
+            )
+        );
+        assert_eq!(
+            iterator.next().await.unwrap().unwrap(),
+            (
                 4,
-                0,
                 Some(UserInner::new(
                     4,
                     "4".to_string(),
@@ -307,131 +382,52 @@ mod tests {
                     0,
                     0,
                     0,
+                    0
+                ))
+            )
+        );
+        assert!(iterator.next().await.is_none());
+
+        let mut iterator = mem_table.range(Some(&2), Some(&3), &0).await.unwrap();
+
+        assert_eq!(
+            iterator.next().await.unwrap().unwrap(),
+            (
+                2,
+                Some(UserInner::new(
+                    2,
+                    "2".to_string(),
+                    false,
                     0,
-                )),
-            );
-
-            let mut iterator = mem_table.iter().await.unwrap();
-
-            assert_eq!(
-                iterator.next().await.unwrap().unwrap(),
-                (
-                    1,
-                    Some(UserInner::new(
-                        1,
-                        "1".to_string(),
-                        false,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0
-                    ))
-                )
-            );
-            assert_eq!(
-                iterator.next().await.unwrap().unwrap(),
-                (
-                    2,
-                    Some(UserInner::new(
-                        3,
-                        "3".to_string(),
-                        false,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0
-                    ))
-                )
-            );
-            assert_eq!(
-                iterator.next().await.unwrap().unwrap(),
-                (
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0
+                ))
+            )
+        );
+        assert_eq!(
+            iterator.next().await.unwrap().unwrap(),
+            (
+                3,
+                Some(UserInner::new(
                     3,
-                    Some(UserInner::new(
-                        3,
-                        "3".to_string(),
-                        false,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0
-                    ))
-                )
-            );
-            assert_eq!(
-                iterator.next().await.unwrap().unwrap(),
-                (
-                    4,
-                    Some(UserInner::new(
-                        4,
-                        "4".to_string(),
-                        false,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0
-                    ))
-                )
-            );
-            assert!(iterator.next().await.is_none());
-
-            let mut iterator = mem_table.range(Some(&2), Some(&3), &0).await.unwrap();
-
-            assert_eq!(
-                iterator.next().await.unwrap().unwrap(),
-                (
-                    2,
-                    Some(UserInner::new(
-                        2,
-                        "2".to_string(),
-                        false,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0
-                    ))
-                )
-            );
-            assert_eq!(
-                iterator.next().await.unwrap().unwrap(),
-                (
-                    3,
-                    Some(UserInner::new(
-                        3,
-                        "3".to_string(),
-                        false,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0
-                    ))
-                )
-            );
-            assert!(iterator.next().await.is_none())
-        });
+                    "3".to_string(),
+                    false,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0
+                ))
+            )
+        );
+        assert!(iterator.next().await.is_none())
     }
 }

--- a/src/oracle.rs
+++ b/src/oracle.rs
@@ -44,7 +44,7 @@ impl<K> WriteConflict<K> {
 }
 
 #[derive(Debug)]
-pub(crate) struct LocalOracle<K>
+pub struct LocalOracle<K>
 where
     K: Ord,
 {

--- a/src/record.rs
+++ b/src/record.rs
@@ -1,7 +1,7 @@
 use std::{io, mem::size_of};
 
-use futures::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use thiserror::Error;
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
 use crate::{
     oracle::TimeStamp,

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -1,7 +1,4 @@
-use executor::futures::{
-    util::{AsyncReadExt, AsyncWriteExt},
-    AsyncRead, AsyncWrite,
-};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
 use crate::{
     serdes::{Decode, Encode},

--- a/src/serdes/arc.rs
+++ b/src/serdes/arc.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use futures::{AsyncRead, AsyncWrite};
+use tokio::io::{AsyncRead, AsyncWrite};
 
 use super::{Decode, Encode};
 

--- a/src/serdes/boolean.rs
+++ b/src/serdes/boolean.rs
@@ -1,6 +1,6 @@
 use std::{io, mem::size_of};
 
-use executor::futures::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
 use crate::serdes::{Decode, Encode};
 

--- a/src/serdes/mod.rs
+++ b/src/serdes/mod.rs
@@ -6,7 +6,7 @@ mod string;
 
 use std::{future::Future, io};
 
-use futures::{AsyncRead, AsyncWrite};
+use tokio::io::{AsyncRead, AsyncWrite};
 
 pub trait Encode: Send + Sync {
     type Error: From<io::Error> + std::error::Error + Send + Sync + 'static;

--- a/src/serdes/num.rs
+++ b/src/serdes/num.rs
@@ -1,6 +1,6 @@
 use std::{io, mem::size_of};
 
-use futures::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
 use super::{Decode, Encode};
 

--- a/src/serdes/option.rs
+++ b/src/serdes/option.rs
@@ -1,7 +1,7 @@
 use std::io;
 
-use futures::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use thiserror::Error;
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
 use super::{Decode, Encode};
 

--- a/src/serdes/string.rs
+++ b/src/serdes/string.rs
@@ -1,6 +1,6 @@
 use std::{io, mem::size_of};
 
-use futures::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
 use super::{Decode, Encode};
 

--- a/src/stream/batch_stream.rs
+++ b/src/stream/batch_stream.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use arrow::record_batch::RecordBatch;
-use executor::futures::{FutureExt, Stream};
+use futures::{Future, Stream};
 use pin_project::pin_project;
 
 use crate::{schema::Schema, stream::StreamError};

--- a/src/stream/buf_stream.rs
+++ b/src/stream/buf_stream.rs
@@ -5,7 +5,7 @@ use std::{
     task::{Context, Poll},
 };
 
-use executor::futures::Stream;
+use futures::Stream;
 
 unsafe impl<K, V, E> Send for BufStream<'_, K, V, E>
 where

--- a/src/stream/level_stream.rs
+++ b/src/stream/level_stream.rs
@@ -7,11 +7,11 @@ use std::{
 use executor::futures::Stream;
 use futures::Future;
 use pin_project::pin_project;
-use snowflake::ProcessUniqueId;
 
 use crate::{
     schema::Schema,
     stream::{table_stream::TableStream, StreamError},
+    wal::FileId,
     DbOption,
 };
 
@@ -23,7 +23,7 @@ where
     lower: Option<S::PrimaryKey>,
     upper: Option<S::PrimaryKey>,
     option: &'stream DbOption,
-    gens: VecDeque<ProcessUniqueId>,
+    gens: VecDeque<FileId>,
     stream: Option<TableStream<'stream, S>>,
 }
 
@@ -33,7 +33,7 @@ where
 {
     pub(crate) async fn new(
         option: &'stream DbOption,
-        gens: Vec<ProcessUniqueId>,
+        gens: Vec<FileId>,
         lower: Option<&S::PrimaryKey>,
         upper: Option<&S::PrimaryKey>,
     ) -> Result<Self, StreamError<S::PrimaryKey, S>> {

--- a/src/stream/level_stream.rs
+++ b/src/stream/level_stream.rs
@@ -4,8 +4,7 @@ use std::{
     task::{Context, Poll},
 };
 
-use executor::futures::Stream;
-use futures::Future;
+use futures::{Future, Stream};
 use pin_project::pin_project;
 
 use crate::{
@@ -25,6 +24,19 @@ where
     option: &'stream DbOption,
     gens: VecDeque<FileId>,
     stream: Option<TableStream<'stream, S>>,
+    future: Option<
+        Pin<
+            Box<
+                dyn Future<
+                        Output = Result<
+                            TableStream<'stream, S>,
+                            StreamError<<S as Schema>::PrimaryKey, S>,
+                        >,
+                    > + Send
+                    + 'stream,
+            >,
+        >,
+    >,
 }
 
 impl<'stream, S> LevelStream<'stream, S>
@@ -50,6 +62,7 @@ where
             option,
             gens,
             stream,
+            future: None,
         })
     }
 }
@@ -61,19 +74,31 @@ where
     type Item = Result<(S::PrimaryKey, Option<S>), StreamError<S::PrimaryKey, S>>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        if let Some(future) = self.future.as_mut() {
+            return match future.as_mut().poll(cx) {
+                Poll::Ready(Ok(stream)) => {
+                    self.stream = Some(stream);
+                    self.poll_next(cx)
+                }
+                Poll::Ready(Err(err)) => Poll::Ready(Some(Err(err))),
+                Poll::Pending => {
+                    self.future = None;
+                    Poll::Pending
+                }
+            };
+        }
         if let Some(stream) = &mut self.stream {
             return match Pin::new(stream).poll_next(cx) {
                 Poll::Ready(None) => match self.gens.pop_front() {
                     None => Poll::Ready(None),
                     Some(gen) => {
+                        let option = self.option;
                         let min = self.lower.clone();
                         let max = self.upper.clone();
-                        let mut future = pin!(TableStream::<S>::new(
-                            self.option,
-                            &gen,
-                            min.as_ref(),
-                            max.as_ref()
-                        ));
+
+                        let mut future = Box::pin(async move {
+                            TableStream::<S>::new(option, &gen, min.as_ref(), max.as_ref()).await
+                        });
 
                         match future.as_mut().poll(cx) {
                             Poll::Ready(Ok(stream)) => {
@@ -81,7 +106,10 @@ where
                                 self.poll_next(cx)
                             }
                             Poll::Ready(Err(err)) => Poll::Ready(Some(Err(err))),
-                            Poll::Pending => Poll::Pending,
+                            Poll::Pending => {
+                                self.future = Some(future);
+                                Poll::Pending
+                            }
                         }
                     }
                 },

--- a/src/stream/merge_stream.rs
+++ b/src/stream/merge_stream.rs
@@ -5,8 +5,7 @@ use std::{
     task::{Context, Poll},
 };
 
-use executor::futures::StreamExt;
-use futures::Stream;
+use futures::{Stream, StreamExt};
 use pin_project::pin_project;
 
 use crate::{
@@ -96,8 +95,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use executor::futures::StreamExt;
-    use futures::executor::block_on;
+    use futures::{executor::block_on, StreamExt};
 
     use crate::{
         stream::{buf_stream::BufStream, merge_stream::MergeStream, EStreamImpl},

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -4,7 +4,7 @@ use std::{
     task::{Context, Poll},
 };
 
-use executor::futures::Stream;
+use futures::Stream;
 use pin_project::pin_project;
 use thiserror::Error;
 

--- a/src/stream/table_stream.rs
+++ b/src/stream/table_stream.rs
@@ -20,12 +20,12 @@ use parquet::arrow::{
     ParquetRecordBatchStreamBuilder, ProjectionMask,
 };
 use pin_project::pin_project;
-use snowflake::ProcessUniqueId;
 
 use crate::{
     schema::Schema,
     serdes::Encode,
     stream::{batch_stream::BatchStream, StreamError},
+    wal::FileId,
     DbOption, Offset,
 };
 
@@ -45,7 +45,7 @@ where
 {
     pub(crate) async fn new(
         option: &DbOption,
-        gen: &ProcessUniqueId,
+        gen: &FileId,
         lower: Option<&S::PrimaryKey>,
         upper: Option<&S::PrimaryKey>,
     ) -> Result<Self, StreamError<S::PrimaryKey, S>> {

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -8,7 +8,7 @@ use std::{
     task::{Context, Poll},
 };
 
-use executor::futures::Stream;
+use futures::Stream;
 use pin_project::pin_project;
 use thiserror::Error;
 

--- a/src/version/cleaner.rs
+++ b/src/version/cleaner.rs
@@ -2,14 +2,13 @@ use std::{collections::BTreeMap, fs, io, sync::Arc};
 
 use executor::futures::StreamExt;
 use futures::channel::mpsc::{channel, Receiver, Sender};
-use snowflake::ProcessUniqueId;
 
-use crate::DbOption;
+use crate::{wal::FileId, DbOption};
 
 pub(crate) enum CleanTag {
     Add {
         version_num: usize,
-        gens: Vec<ProcessUniqueId>,
+        gens: Vec<FileId>,
     },
     Clean {
         version_num: usize,
@@ -18,7 +17,7 @@ pub(crate) enum CleanTag {
 
 pub(crate) struct Cleaner {
     tag_recv: Receiver<CleanTag>,
-    gens_map: BTreeMap<usize, (Vec<ProcessUniqueId>, bool)>,
+    gens_map: BTreeMap<usize, (Vec<FileId>, bool)>,
     option: Arc<DbOption>,
 }
 

--- a/src/version/cleaner.rs
+++ b/src/version/cleaner.rs
@@ -1,7 +1,9 @@
 use std::{collections::BTreeMap, fs, io, sync::Arc};
 
-use executor::futures::StreamExt;
-use futures::channel::mpsc::{channel, Receiver, Sender};
+use futures::{
+    channel::mpsc::{channel, Receiver, Sender},
+    StreamExt,
+};
 
 use crate::{wal::FileId, DbOption};
 

--- a/src/version/edit.rs
+++ b/src/version/edit.rs
@@ -1,9 +1,6 @@
 use std::mem::size_of;
 
-use executor::futures::{
-    util::{AsyncReadExt, AsyncWriteExt},
-    AsyncRead, AsyncWrite,
-};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
 use crate::{
     scope::Scope,
@@ -109,7 +106,9 @@ where
 
 #[cfg(test)]
 mod tests {
-    use futures::{executor::block_on, io::Cursor};
+    use std::io::Cursor;
+
+    use futures::executor::block_on;
 
     use crate::{scope::Scope, serdes::Encode, version::edit::VersionEdit, wal::FileId};
 

--- a/src/version/mod.rs
+++ b/src/version/mod.rs
@@ -20,7 +20,6 @@ use parquet::arrow::{
     arrow_reader::{ArrowPredicateFn, ArrowReaderMetadata, RowFilter},
     ParquetRecordBatchStreamBuilder, ProjectionMask,
 };
-use snowflake::ProcessUniqueId;
 use thiserror::Error;
 use tracing::error;
 
@@ -30,6 +29,7 @@ use crate::{
     serdes::Encode,
     stream::{level_stream::LevelStream, table_stream::TableStream, EStreamImpl, StreamError},
     version::cleaner::CleanTag,
+    wal::FileId,
     DbOption,
 };
 
@@ -149,7 +149,7 @@ where
     }
 
     async fn read_parquet(
-        scope_gen: &ProcessUniqueId,
+        scope_gen: &FileId,
         key_scalar: &S::PrimaryKeyArray,
         option: &DbOption,
     ) -> Result<Option<RecordBatch>, VersionError<S>> {

--- a/src/version/set.rs
+++ b/src/version/set.rs
@@ -1,11 +1,11 @@
 use std::{fs::OpenOptions, io::SeekFrom, sync::Arc};
 
 use async_lock::RwLock;
-use executor::{
+use futures::{channel::mpsc::Sender, SinkExt};
+use tokio::{
     fs,
-    futures::{util::SinkExt, AsyncSeekExt, AsyncWriteExt},
+    io::{AsyncSeekExt, AsyncWriteExt},
 };
-use futures::channel::mpsc::Sender;
 
 use crate::{
     schema::Schema,

--- a/src/wal/provider/fs.rs
+++ b/src/wal/provider/fs.rs
@@ -6,10 +6,11 @@ use std::{
 };
 
 use async_stream::stream;
-use executor::futures::Stream;
+use futures::Stream;
 use itertools::Itertools;
 use once_cell::sync::Lazy;
 use regex::Regex;
+use tokio::fs::File;
 
 use super::WalProvider;
 use crate::wal::FileId;
@@ -31,7 +32,7 @@ impl Fs {
 }
 
 impl WalProvider for Fs {
-    type File = executor::fs::File;
+    type File = File;
 
     async fn open(&self, fid: FileId) -> io::Result<Self::File> {
         Ok(OpenOptions::new()

--- a/src/wal/provider/mod.rs
+++ b/src/wal/provider/mod.rs
@@ -5,10 +5,15 @@ use std::{future::Future, io};
 
 use executor::futures::Stream;
 
+use crate::wal::FileId;
+
 pub trait WalProvider: Send + Sync + 'static {
     type File: Unpin + Send + Sync + 'static;
 
-    fn open(&self, fid: u32) -> impl Future<Output = io::Result<Self::File>>;
+    fn open(&self, fid: FileId) -> impl Future<Output = io::Result<Self::File>>;
 
-    fn list(&self) -> impl Stream<Item = io::Result<Self::File>>;
+    // FIXME: async
+    fn remove(&self, fid: FileId) -> io::Result<()>;
+
+    fn list(&self) -> io::Result<impl Stream<Item = io::Result<(Self::File, FileId)>>>;
 }

--- a/src/wal/provider/mod.rs
+++ b/src/wal/provider/mod.rs
@@ -3,7 +3,7 @@ pub mod in_mem;
 
 use std::{future::Future, io};
 
-use executor::futures::Stream;
+use futures::Stream;
 
 use crate::wal::FileId;
 


### PR DESCRIPTION
- Removed Thread-Per-Core feature
- Use Ulid to name SSTable and WAL, and delete them during Minor Compaction.
- [change async runtime executor -> tokio](https://github.com/from-the-basement/elsm/pull/32/commits/54352dbb5c3c1af8feec54eca54524ecd75bfb15)